### PR TITLE
feat(home): implement Home feature with ViewModel, state management, UI, and integration with book details resolver

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+API_BASE_URL=https://681d018ff74de1d219ae8534.mockapi.io/api/v1
+CATALOG_BASE_URL=https://www.googleapis.com/books/v1

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:book_library/src/core/app/main_app.dart';
 import 'package:book_library/src/core/di/injector.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -12,6 +13,7 @@ void main() async {
   final prefs = await SharedPreferences.getInstance();
   getIt.registerLazySingleton<SharedPreferences>(() => prefs);
 
+  await dotenv.load(fileName: '.env');
   await setupInjector();
 
   runApp(const MainApp());

--- a/lib/src/core/constants/api_paths.dart
+++ b/lib/src/core/constants/api_paths.dart
@@ -1,0 +1,5 @@
+abstract class ApiPaths {
+  static const String version = '/v1';
+  static const String books = '/books';
+  static const String volumes = '/volumes';
+}

--- a/lib/src/core/constants/app_env.dart
+++ b/lib/src/core/constants/app_env.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+abstract class AppEnv {
+  static String get apiBaseUrl => dotenv.env['API_BASE_URL']!;
+
+  static String get catalogBaseUrl => dotenv.env['CATALOG_BASE_URL']!;
+}

--- a/lib/src/core/di/injector.dart
+++ b/lib/src/core/di/injector.dart
@@ -1,5 +1,33 @@
+import 'package:book_library/src/core/constants/app_env.dart';
+import 'package:book_library/src/core/network/dio_factory.dart';
+import 'package:book_library/src/core/services/cache/cache.dart';
+import 'package:book_library/src/core/services/cache/lru_cache.dart';
+import 'package:book_library/src/core/services/coalescing/inflight_coalescer.dart';
+import 'package:book_library/src/core/services/coalescing/map_inflight_coalescer.dart';
+import 'package:book_library/src/core/services/concurrency/concurrency_limiter.dart';
+import 'package:book_library/src/core/services/concurrency/semaphore_limiter.dart';
+import 'package:book_library/src/core/services/key/canonical_key_strategy.dart';
+import 'package:book_library/src/core/services/key/default_canonical_key.dart';
 import 'package:book_library/src/core/storage/wrapper/shared_preferences_wrapper.dart';
 import 'package:book_library/src/core/theme/app_theme_controller.dart';
+import 'package:book_library/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source.dart';
+import 'package:book_library/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source_impl.dart';
+import 'package:book_library/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source.dart';
+import 'package:book_library/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source_impl.dart';
+import 'package:book_library/src/features/books/data/repositories/books_repository_impl.dart';
+import 'package:book_library/src/features/books/data/repositories/categories_repository_impl.dart';
+import 'package:book_library/src/features/books/domain/repositories/books_repository.dart';
+import 'package:book_library/src/features/books/domain/repositories/categories_repository.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_all_books_use_case.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_categories_use_case.dart';
+import 'package:book_library/src/features/books_details/data/datasources/external_catalog_remote_data_source.dart';
+import 'package:book_library/src/features/books_details/data/datasources/external_catalog_remote_data_source_impl.dart';
+import 'package:book_library/src/features/books_details/data/repositories/books_details_repository_impl.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/books_details/domain/repositories/book_details_repository.dart';
+import 'package:book_library/src/features/books_details/domain/use_cases/get_book_details_use_case.dart';
+import 'package:book_library/src/features/books_details/services/external_book_info_resolver.dart';
+import 'package:book_library/src/features/home/presentation/view_model/home_view_model.dart';
 import 'package:book_library/src/features/launcher/presentation/view_model/launcher_view_model.dart';
 import 'package:book_library/src/features/onboard/data/datasources/local_data_source.dart';
 import 'package:book_library/src/features/onboard/data/datasources/local_data_source_impl.dart';
@@ -9,6 +37,7 @@ import 'package:book_library/src/features/onboard/domain/use_cases/get_onboardin
 import 'package:book_library/src/features/onboard/domain/use_cases/set_onboarding_done_use_case.dart';
 import 'package:book_library/src/features/onboard/presentation/services/onboard_content_provider.dart';
 import 'package:book_library/src/features/onboard/presentation/view_model/onboard_view_model.dart';
+import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
 
 final GetIt getIt = GetIt.instance;
@@ -19,9 +48,33 @@ Future<void> setupInjector() async {
 
   /// -----------Infrastructure--------------
   getIt.registerLazySingleton<OnboardingRepository>(() => OnboardingRepositoryImpl(getIt()));
+  getIt.registerLazySingleton<BooksRepository>(() => BooksRepositoryImpl(getIt()));
+  getIt.registerLazySingleton<CategoriesRepository>(() => CategoriesRepositoryImpl(getIt()));
+
+  getIt.registerLazySingleton<Dio>(
+    () => DioFactory.create(baseUrl: AppEnv.apiBaseUrl),
+    instanceName: 'api',
+  );
+  getIt.registerLazySingleton<Dio>(
+    () => DioFactory.create(baseUrl: AppEnv.catalogBaseUrl),
+    instanceName: 'catalog',
+  );
+
+  getIt.registerLazySingleton<CategoriesFakeDataSource>(() => CategoriesFakeDataSourceImpl());
 
   getIt.registerLazySingleton<OnboardingLocalDataSource>(
     () => OnboardingLocalDataSourceImpl(getIt()),
+  );
+
+  getIt.registerLazySingleton<BooksRemoteDataSource>(
+    () => BooksRemoteDataSourceImpl(getIt<Dio>(instanceName: 'api')),
+  );
+
+  getIt.registerLazySingleton<ExternalCatalogRemoteDataSource>(
+    () => ExternalCatalogRemoteDataSourceImpl(getIt<Dio>(instanceName: 'catalog')),
+  );
+  getIt.registerLazySingleton<ExternalBookInfoRepository>(
+    () => ExternalBookInfoRepositoryImpl(getIt()),
   );
 
   /// -------------Onboard-------------------
@@ -31,12 +84,37 @@ Future<void> setupInjector() async {
   /// --------------Launcher-----------------
   getIt.registerFactory<LauncherViewModel>(() => LauncherViewModel(getIt()));
 
+  /// ----------------Home-------------------
+  getIt.registerFactory<HomeViewModel>(() => HomeViewModel(getIt(), getIt(), getIt()));
+
   /// --------------Use Cases-----------------
+  getIt.registerLazySingleton<GetAllBooksUseCase>(() => GetAllBooksUseCaseImpl(getIt()));
+  getIt.registerLazySingleton<GetCategoriesUseCase>(() => GetCategoriesUseCaseImpl(getIt()));
+  getIt.registerLazySingleton<GetBookDetailsUseCase>(() => GetBookDetailsUseCaseImpl(getIt()));
   getIt.registerLazySingleton<GetOnboardingDoneUseCase>(
     () => GetOnboardingDoneUseCaseImpl(getIt()),
   );
+
   getIt.registerLazySingleton<SetOnboardingDoneUseCase>(
     () => SetOnboardingDoneUseCaseImpl(getIt()),
+  );
+
+  // -------------- CACHE -------------------
+  getIt.registerLazySingleton<CanonicalKeyStrategy>(() => DefaultCanonicalKey());
+  getIt.registerLazySingleton<Cache<String, ExternalBookInfoEntity?>>(() => LruCache(256));
+  getIt.registerLazySingleton<ConcurrencyLimiter>(() => SemaphoreLimiter(6));
+  getIt.registerLazySingleton<InflightCoalescer<String, ExternalBookInfoEntity?>>(
+    () => MapInflightCoalescer(),
+  );
+
+  getIt.registerLazySingleton<ExternalBookInfoResolver>(
+    () => ExternalBookInfoResolver(
+      usecase: getIt(),
+      cache: getIt(),
+      limiter: getIt(),
+      coalescer: getIt(),
+      keyOf: getIt(),
+    ),
   );
 
   await getIt.allReady();

--- a/lib/src/core/failures/failures.dart
+++ b/lib/src/core/failures/failures.dart
@@ -25,3 +25,7 @@ final class StorageFailure extends Failure {
 final class NetworkFailure extends Failure {
   const NetworkFailure(super.message, {super.cause, super.stackTrace});
 }
+
+class FakeFailure extends Failure {
+  const FakeFailure(super.message, {super.cause, super.stackTrace});
+}

--- a/lib/src/core/network/dio_factory.dart
+++ b/lib/src/core/network/dio_factory.dart
@@ -1,0 +1,34 @@
+import 'package:dio/dio.dart';
+
+class DioFactory {
+  static Dio create({
+    required String baseUrl,
+    List<Interceptor> interceptors = const [],
+    Duration connectTimeout = const Duration(seconds: 10),
+    Duration receiveTimeout = const Duration(seconds: 10),
+  }) {
+    final dio = Dio(
+      BaseOptions(
+        baseUrl: baseUrl,
+        connectTimeout: connectTimeout,
+        receiveTimeout: receiveTimeout,
+        contentType: 'application/json',
+      ),
+    );
+
+    // if (kDebugMode) {
+    //   dio.interceptors.add(
+    //     LogInterceptor(
+    //       requestBody: false,
+    //       responseBody: false,
+    //       requestHeader: false,
+    //       responseHeader: false,
+    //       request: false,
+    //     ),
+    //   );
+    // }
+
+    // dio.interceptors.addAll(interceptors);
+    return dio;
+  }
+}

--- a/lib/src/core/presentation/views/offiline_view.dart
+++ b/lib/src/core/presentation/views/offiline_view.dart
@@ -1,0 +1,68 @@
+import 'package:book_library/src/core/presentation/extensions/color_ext.dart';
+import 'package:book_library/src/core/presentation/widgets/book_library_button.dart';
+import 'package:book_library/src/core/theme/app_text_styles.dart';
+import 'package:flutter/material.dart';
+
+class OfflineView extends StatelessWidget {
+  const OfflineView({super.key, required this.onRetry, required this.onOpenSettings});
+
+  final VoidCallback onRetry;
+  final VoidCallback onOpenSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colors;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 120,
+            height: 120,
+            decoration: BoxDecoration(shape: BoxShape.circle, color: colors.tapEffect),
+            child: Icon(Icons.cloud_off_outlined, size: 56, color: colors.border),
+          ),
+          const SizedBox(height: 32),
+
+          Text(
+            "You're offline",
+            style: AppTextStyles.h5.copyWith(color: colors.textPrimary),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+
+          Text(
+            'Connect to the internet to access your library and continue reading your books.',
+            style: AppTextStyles.body2Regular.copyWith(color: colors.textSecondary),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 32),
+
+          BookLibraryButton(
+            text: 'Retry',
+            onPressed: onRetry,
+            textStyle: AppTextStyles.subtitle1Medium.copyWith(color: colors.textLight),
+          ),
+          const SizedBox(height: 12),
+
+          TextButton(
+            onPressed: onOpenSettings,
+            child: Text(
+              'Open Settings',
+              style: AppTextStyles.body1Regular.copyWith(color: colors.primary),
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          Text(
+            'Check your WiFi connection or mobile data settings to get back online.',
+            style: AppTextStyles.caption.copyWith(color: colors.textSecondary),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/core/presentation/widgets/book_library_bottom_navigation_bar.dart
+++ b/lib/src/core/presentation/widgets/book_library_bottom_navigation_bar.dart
@@ -1,0 +1,34 @@
+import 'package:book_library/src/core/routes/app_routes.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class BookLibraryBottomNavigationBar extends StatelessWidget {
+  const BookLibraryBottomNavigationBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: 0,
+      onTap: (i) {
+        switch (i) {
+          case 0:
+            break;
+          case 1:
+            context.goNamed(AppRoutes.explore);
+            break;
+          case 2:
+            context.goNamed(AppRoutes.saved);
+            break;
+          case 3:
+            break;
+        }
+      },
+      items: const [
+        BottomNavigationBarItem(icon: Icon(Icons.home_filled), label: 'Home'),
+        BottomNavigationBarItem(icon: Icon(Icons.explore_outlined), label: 'Explore'),
+        BottomNavigationBarItem(icon: Icon(Icons.bookmark_border), label: 'Saved'),
+        BottomNavigationBarItem(icon: Icon(Icons.person_outline), label: 'Profile'),
+      ],
+    );
+  }
+}

--- a/lib/src/core/routes/app_router.dart
+++ b/lib/src/core/routes/app_router.dart
@@ -20,7 +20,11 @@ GoRouter buildRouter() {
         path: '/onboard',
         builder: (context, state) => OnboardView(viewModel: getIt()),
       ),
-      GoRoute(name: AppRoutes.home, path: '/home', builder: (context, state) => const HomeView()),
+      GoRoute(
+        name: AppRoutes.home,
+        path: '/home',
+        builder: (context, state) => HomeView(viewModel: getIt()),
+      ),
     ],
   );
 }

--- a/lib/src/core/services/cache/cache.dart
+++ b/lib/src/core/services/cache/cache.dart
@@ -1,0 +1,4 @@
+abstract class Cache<K, V> {
+  V? get(K key);
+  void set(K key, V value);
+}

--- a/lib/src/core/services/cache/lru_cache.dart
+++ b/lib/src/core/services/cache/lru_cache.dart
@@ -1,0 +1,43 @@
+import 'package:book_library/src/core/services/cache/cache.dart';
+
+// Explicação Sobre o que é um LRU Cache em português
+// durante o desenvolvimento desse software eu quis deixar mais rico a apresentação dos livros
+// e para isso precisei buscar informações em uma API externa, mas como essas informações
+// porém vários livros significa várias requisições, e várias requisições significa
+// mais tempo de espera para o usuário, e mais custo para o servidor que hospeda a API.
+// Para mitigar esse problema eu precisei pesquisar e estudar algumas técnicas de otimização
+// e uma delas foi o LRU Cache, que é uma técnica de cache que armazena os dados mais
+// recentemente usados, e descarta os dados menos usados quando o cache atinge sua capacidade máxima.
+// LRU significa "Least Recently Used", ou "Menos Recentemente Usado" em português.
+// A ideia é simples: quando um dado é acessado, ele é movido para o topo da lista de dados mais
+// recentemente usados. Quando o cache atinge sua capacidade máxima, o dado que está no
+// final da lista (o menos recentemente usado) é removido para dar lugar ao novo dado.
+// Isso garante que os dados mais relevantes e frequentemente acessados estejam sempre disponíveis
+// no cache, melhorando a performance do sistema como um todo.
+//
+// Assim eu não precisaria fazer tantas requisições para a API externa, melhorando a experiência do usuário
+// e reduzindo o custo para o servidor que hospeda a API.
+
+class LruCache<K, V> implements Cache<K, V> {
+  LruCache(this.capacity);
+  final int capacity;
+  final _map = <K, V>{};
+
+  @override
+  V? get(K key) {
+    if (!_map.containsKey(key)) return null;
+    final v = _map.remove(key) as V;
+    _map[key] = v;
+    return v;
+  }
+
+  @override
+  void set(K key, V value) {
+    if (_map.containsKey(key)) _map.remove(key);
+    _map[key] = value;
+    if (_map.length > capacity) _map.remove(_map.keys.first);
+  }
+
+  int get length => _map.length;
+  Iterable<K> get keys => _map.keys;
+}

--- a/lib/src/core/services/coalescing/inflight_coalescer.dart
+++ b/lib/src/core/services/coalescing/inflight_coalescer.dart
@@ -1,0 +1,3 @@
+abstract class InflightCoalescer<K, V> {
+  Future<V> run(K key, Future<V> Function() task);
+}

--- a/lib/src/core/services/coalescing/map_inflight_coalescer.dart
+++ b/lib/src/core/services/coalescing/map_inflight_coalescer.dart
@@ -1,0 +1,13 @@
+import 'package:book_library/src/core/services/coalescing/inflight_coalescer.dart';
+
+class MapInflightCoalescer<K, V> implements InflightCoalescer<K, V> {
+  final _inflight = <K, Future<V>>{};
+  @override
+  Future<V> run(K key, Future<V> Function() task) {
+    final existing = _inflight[key];
+    if (existing != null) return existing;
+    final future = task();
+    _inflight[key] = future;
+    return future.whenComplete(() => _inflight.remove(key));
+  }
+}

--- a/lib/src/core/services/concurrency/concurrency_limiter.dart
+++ b/lib/src/core/services/concurrency/concurrency_limiter.dart
@@ -1,0 +1,4 @@
+abstract class ConcurrencyLimiter {
+  Future<void> acquire();
+  void release();
+}

--- a/lib/src/core/services/concurrency/semaphore_limiter.dart
+++ b/lib/src/core/services/concurrency/semaphore_limiter.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:book_library/src/core/services/concurrency/concurrency_limiter.dart';
+
+class SemaphoreLimiter implements ConcurrencyLimiter {
+  SemaphoreLimiter(this._max);
+
+  int _current = 0;
+  final int _max;
+  final Queue<Completer<void>> _q = Queue();
+
+  @override
+  Future<void> acquire() async {
+    if (_current < _max) {
+      _current++;
+      return;
+    }
+    final c = Completer<void>();
+    _q.add(c);
+    await c.future;
+  }
+
+  @override
+  void release() {
+    if (_q.isNotEmpty) {
+      _q.removeFirst().complete();
+    } else {
+      _current = (_current - 1).clamp(0, _max);
+    }
+  }
+}

--- a/lib/src/core/services/key/canonical_key_strategy.dart
+++ b/lib/src/core/services/key/canonical_key_strategy.dart
@@ -1,0 +1,3 @@
+abstract class CanonicalKeyStrategy {
+  String call(String title, String author);
+}

--- a/lib/src/core/services/key/default_canonical_key.dart
+++ b/lib/src/core/services/key/default_canonical_key.dart
@@ -1,0 +1,7 @@
+import 'package:book_library/src/core/services/key/canonical_key_strategy.dart';
+
+class DefaultCanonicalKey implements CanonicalKeyStrategy {
+  String _norm(String s) => s.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+  @override
+  String call(String title, String author) => '${_norm(title)}|${_norm(author)}';
+}

--- a/lib/src/core/theme/app_text_styles.dart
+++ b/lib/src/core/theme/app_text_styles.dart
@@ -31,6 +31,9 @@ abstract class AppTextStyles {
   static TextStyle get caption =>
       const TextStyle(fontSize: 12, fontFamily: 'Roboto', fontWeight: FontWeight.w400);
 
+  static TextStyle get captionBold =>
+      const TextStyle(fontSize: 12, fontFamily: 'Roboto', fontWeight: FontWeight.w700);
+
   static TextStyle get button =>
       const TextStyle(fontSize: 14, fontFamily: 'Roboto', fontWeight: FontWeight.w500);
 }

--- a/lib/src/core/theme/app_theme.dart
+++ b/lib/src/core/theme/app_theme.dart
@@ -31,12 +31,21 @@ abstract class AppTheme {
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
       ),
+      bottomNavigationBarTheme: BottomNavigationBarThemeData(
+        backgroundColor: colors.surface,
+        selectedItemColor: colors.primary,
+        unselectedItemColor: colors.textSecondary,
+        selectedLabelStyle: AppTextStyles.captionBold,
+        unselectedLabelStyle: AppTextStyles.caption,
+        type: BottomNavigationBarType.fixed,
+      ),
       popupMenuTheme: PopupMenuThemeData(
         color: Colors.white,
         textStyle: AppTextStyles.body1Regular,
       ),
       appBarTheme: AppBarTheme(
         backgroundColor: colors.background,
+        surfaceTintColor: colors.background,
         foregroundColor: colors.textPrimary,
         elevation: 0,
         centerTitle: false,

--- a/lib/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source.dart
+++ b/lib/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source.dart
@@ -1,0 +1,3 @@
+abstract class BooksRemoteDataSource {
+  Future<List<Map<String, dynamic>>> fetchBooks();
+}

--- a/lib/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source_impl.dart
+++ b/lib/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source_impl.dart
@@ -1,0 +1,15 @@
+import 'package:book_library/src/core/constants/api_paths.dart';
+import 'package:book_library/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source.dart';
+import 'package:dio/dio.dart';
+
+class BooksRemoteDataSourceImpl implements BooksRemoteDataSource {
+  const BooksRemoteDataSourceImpl(this.dio);
+  final Dio dio;
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchBooks() async {
+    final res = await dio.get(ApiPaths.books);
+    final data = res.data as List<dynamic>;
+    return data.cast<Map<String, dynamic>>();
+  }
+}

--- a/lib/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source.dart
+++ b/lib/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source.dart
@@ -1,0 +1,3 @@
+abstract class CategoriesFakeDataSource {
+  Future<List<Map<String, dynamic>>> fetchCategories();
+}

--- a/lib/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source_impl.dart
+++ b/lib/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source_impl.dart
@@ -1,0 +1,14 @@
+import 'package:book_library/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source.dart';
+
+class CategoriesFakeDataSourceImpl implements CategoriesFakeDataSource {
+  @override
+  Future<List<Map<String, dynamic>>> fetchCategories() async {
+    return [
+      {'id': '1', 'name': 'Romance'},
+      {'id': '2', 'name': 'Fantasy'},
+      {'id': '3', 'name': 'Sci-Fi'},
+      {'id': '4', 'name': 'Business'},
+      {'id': '5', 'name': 'Technology'},
+    ];
+  }
+}

--- a/lib/src/features/books/data/mappers/book_mapper.dart
+++ b/lib/src/features/books/data/mappers/book_mapper.dart
@@ -1,0 +1,34 @@
+import 'package:book_library/src/features/books/data/models/book_model.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:intl/intl.dart';
+
+abstract class BookMapper {
+  static BookEntity toEntity(BookModel model) {
+    DateTime? publishedDate;
+    final raw = model.published?.trim();
+    if (raw != null && raw.isNotEmpty) {
+      try {
+        publishedDate =
+            DateTime.tryParse(raw) ?? DateFormat('yyyy-MM-dd').parse(raw, true).toLocal();
+      } catch (_) {}
+    }
+
+    return BookEntity(
+      id: model.id,
+      title: model.title,
+      author: model.author,
+      published: publishedDate,
+      publisher: model.publisher,
+    );
+  }
+
+  static BookModel toModel(BookEntity entity) {
+    return BookModel(
+      id: entity.id,
+      title: entity.title,
+      author: entity.author,
+      published: entity.published?.toIso8601String(),
+      publisher: entity.publisher,
+    );
+  }
+}

--- a/lib/src/features/books/data/mappers/category_mapper.dart
+++ b/lib/src/features/books/data/mappers/category_mapper.dart
@@ -1,0 +1,12 @@
+import 'package:book_library/src/features/books/data/models/category_model.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+
+abstract class CategoryMapper {
+  static CategoryEntity toEntity(CategoryModel model) {
+    return CategoryEntity(id: model.id, name: model.name);
+  }
+
+  static CategoryModel toModel(CategoryEntity entity) {
+    return CategoryModel(id: entity.id, name: entity.name);
+  }
+}

--- a/lib/src/features/books/data/models/book_model.dart
+++ b/lib/src/features/books/data/models/book_model.dart
@@ -1,0 +1,23 @@
+class BookModel {
+  factory BookModel.fromJson(Map<String, dynamic> json) => BookModel(
+    id: json['id']?.toString() ?? '',
+    title: (json['title'] as String?)?.trim() ?? '',
+    author: (json['author'] as String?)?.trim() ?? '',
+    published: json['published'] as String?,
+    publisher: (json['publisher'] as String?)?.trim(),
+  );
+
+  const BookModel({
+    required this.id,
+    required this.title,
+    required this.author,
+    this.published,
+    this.publisher,
+  });
+
+  final String id;
+  final String title;
+  final String author;
+  final String? published;
+  final String? publisher;
+}

--- a/lib/src/features/books/data/models/category_model.dart
+++ b/lib/src/features/books/data/models/category_model.dart
@@ -1,0 +1,17 @@
+class CategoryModel {
+  const CategoryModel({required this.id, required this.name});
+
+  factory CategoryModel.fromJson(Map<String, dynamic> json) {
+    return CategoryModel(id: json['id'], name: json['name']);
+  }
+
+  final String id;
+  final String name;
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['id'] = id;
+    data['name'] = name;
+    return data;
+  }
+}

--- a/lib/src/features/books/data/repositories/books_repository_impl.dart
+++ b/lib/src/features/books/data/repositories/books_repository_impl.dart
@@ -1,0 +1,40 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source.dart';
+import 'package:book_library/src/features/books/data/mappers/book_mapper.dart';
+import 'package:book_library/src/features/books/data/models/book_model.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/repositories/books_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class BooksRepositoryImpl implements BooksRepository {
+  const BooksRepositoryImpl(this.remote);
+  final BooksRemoteDataSource remote;
+
+  @override
+  Future<Either<Failure, List<BookEntity>>> getAll() async {
+    try {
+      final raw = await remote.fetchBooks();
+      final entities = raw
+          .map((m) => BookMapper.toEntity(BookModel.fromJson(m)))
+          .toList(growable: false);
+      return Right(entities);
+    } catch (e, s) {
+      return Left(NetworkFailure('Failed to fetch books', cause: e, stackTrace: s));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<BookEntity>>> searchByTitle(String query) async {
+    try {
+      final raw = await remote.fetchBooks();
+      final q = query.trim().toLowerCase();
+      final entities = raw
+          .map((m) => BookMapper.toEntity(BookModel.fromJson(m)))
+          .where((b) => b.title.toLowerCase().contains(q))
+          .toList(growable: false);
+      return Right(entities);
+    } catch (e, s) {
+      return Left(NetworkFailure('Failed to search books', cause: e, stackTrace: s));
+    }
+  }
+}

--- a/lib/src/features/books/data/repositories/categories_repository_impl.dart
+++ b/lib/src/features/books/data/repositories/categories_repository_impl.dart
@@ -1,0 +1,25 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source.dart';
+import 'package:book_library/src/features/books/data/mappers/category_mapper.dart';
+import 'package:book_library/src/features/books/data/models/category_model.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+import 'package:book_library/src/features/books/domain/repositories/categories_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class CategoriesRepositoryImpl implements CategoriesRepository {
+  const CategoriesRepositoryImpl(this.dataSource);
+  final CategoriesFakeDataSource dataSource;
+
+  @override
+  Future<Either<Failure, List<CategoryEntity>>> getAll() async {
+    try {
+      final raw = await dataSource.fetchCategories();
+      final entities = raw
+          .map((m) => CategoryMapper.toEntity(CategoryModel.fromJson(m)))
+          .toList(growable: false);
+      return Right(entities);
+    } catch (e, s) {
+      return Left(FakeFailure('Failed to load categories', cause: e, stackTrace: s));
+    }
+  }
+}

--- a/lib/src/features/books/domain/entities/book_entity.dart
+++ b/lib/src/features/books/domain/entities/book_entity.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+
+class BookEntity extends Equatable {
+  const BookEntity({
+    required this.id,
+    required this.title,
+    required this.author,
+    this.publisher,
+    this.published,
+  });
+
+  final String id;
+  final String title;
+  final String author;
+  final DateTime? published;
+  final String? publisher;
+
+  @override
+  List<Object?> get props => [id, title, author, published, publisher];
+}

--- a/lib/src/features/books/domain/entities/category_entity.dart
+++ b/lib/src/features/books/domain/entities/category_entity.dart
@@ -1,0 +1,10 @@
+import 'package:equatable/equatable.dart';
+
+class CategoryEntity extends Equatable {
+  const CategoryEntity({required this.id, required this.name});
+  final String id;
+  final String name;
+
+  @override
+  List<Object?> get props => [id, name];
+}

--- a/lib/src/features/books/domain/repositories/books_repository.dart
+++ b/lib/src/features/books/domain/repositories/books_repository.dart
@@ -1,0 +1,8 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:dartz/dartz.dart';
+
+abstract class BooksRepository {
+  Future<Either<Failure, List<BookEntity>>> getAll();
+  Future<Either<Failure, List<BookEntity>>> searchByTitle(String query);
+}

--- a/lib/src/features/books/domain/repositories/categories_repository.dart
+++ b/lib/src/features/books/domain/repositories/categories_repository.dart
@@ -1,0 +1,7 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+import 'package:dartz/dartz.dart';
+
+abstract class CategoriesRepository {
+  Future<Either<Failure, List<CategoryEntity>>> getAll();
+}

--- a/lib/src/features/books/domain/usecases/get_all_books_use_case.dart
+++ b/lib/src/features/books/domain/usecases/get_all_books_use_case.dart
@@ -1,0 +1,18 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/repositories/books_repository.dart';
+import 'package:dartz/dartz.dart';
+
+abstract class GetAllBooksUseCase {
+  const GetAllBooksUseCase();
+
+  Future<Either<Failure, List<BookEntity>>> call();
+}
+
+class GetAllBooksUseCaseImpl extends GetAllBooksUseCase {
+  const GetAllBooksUseCaseImpl(this.repository);
+  final BooksRepository repository;
+
+  @override
+  Future<Either<Failure, List<BookEntity>>> call() => repository.getAll();
+}

--- a/lib/src/features/books/domain/usecases/get_book_by_title_use_case.dart
+++ b/lib/src/features/books/domain/usecases/get_book_by_title_use_case.dart
@@ -1,0 +1,18 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/repositories/books_repository.dart';
+import 'package:dartz/dartz.dart';
+
+abstract class GetBookByTitleUseCase {
+  const GetBookByTitleUseCase();
+
+  Future<Either<Failure, List<BookEntity>>> call(String query);
+}
+
+class GetBookByTitleUseCaseImpl extends GetBookByTitleUseCase {
+  const GetBookByTitleUseCaseImpl(this.repository);
+  final BooksRepository repository;
+
+  @override
+  Future<Either<Failure, List<BookEntity>>> call(String query) => repository.searchByTitle(query);
+}

--- a/lib/src/features/books/domain/usecases/get_categories_use_case.dart
+++ b/lib/src/features/books/domain/usecases/get_categories_use_case.dart
@@ -1,0 +1,20 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+import 'package:book_library/src/features/books/domain/repositories/categories_repository.dart';
+import 'package:dartz/dartz.dart';
+
+abstract class GetCategoriesUseCase {
+  const GetCategoriesUseCase();
+
+  Future<Either<Failure, List<CategoryEntity>>> call();
+}
+
+class GetCategoriesUseCaseImpl extends GetCategoriesUseCase {
+  const GetCategoriesUseCaseImpl(this.repository);
+  final CategoriesRepository repository;
+
+  @override
+  Future<Either<Failure, List<CategoryEntity>>> call() {
+    return repository.getAll();
+  }
+}

--- a/lib/src/features/books/presentation/widgets/book_card.dart
+++ b/lib/src/features/books/presentation/widgets/book_card.dart
@@ -1,0 +1,127 @@
+import 'package:book_library/src/core/presentation/extensions/color_ext.dart';
+import 'package:book_library/src/core/theme/app_text_styles.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/presentation/widgets/book_cover_placeholder.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:flutter/material.dart';
+
+class BookCard extends StatelessWidget {
+  const BookCard({
+    super.key,
+    required this.book,
+    this.info,
+    this.onTap,
+    required this.showPercentage,
+    required this.showStars,
+  });
+
+  final BookEntity book;
+  final ExternalBookInfoEntity? info;
+  final VoidCallback? onTap;
+  final bool showPercentage;
+  final bool showStars;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colors;
+    final coverUrl = info?.coverUrl;
+
+    return InkWell(
+      borderRadius: BorderRadius.circular(16),
+      onTap: onTap,
+      child: Container(
+        width: 220,
+        decoration: BoxDecoration(
+          color: colors.surface,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: colors.border),
+        ),
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            LayoutBuilder(
+              builder: (context, constraints) {
+                return SizedBox(
+                  width: constraints.maxWidth,
+                  height: 260,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: Builder(
+                      builder: (context) {
+                        if (info == null) {
+                          return const BookCoverPlaceholder();
+                        }
+
+                        if (coverUrl != null && coverUrl.isNotEmpty) {
+                          return Image.network(
+                            coverUrl,
+                            fit: BoxFit.cover,
+                            loadingBuilder: (context, child, event) {
+                              if (event == null) return child;
+                              return const BookCoverPlaceholder();
+                            },
+                            errorBuilder: (_, __, ___) => Container(
+                              color: colors.tapEffect,
+                              child: const Center(child: BookCoverPlaceholder(isNotFound: true)),
+                            ),
+                          );
+                        }
+
+                        return Container(
+                          color: colors.tapEffect,
+                          child: const Center(child: BookCoverPlaceholder(isNotFound: true)),
+                        );
+                      },
+                    ),
+                  ),
+                );
+              },
+            ),
+
+            const SizedBox(height: 12),
+
+            Text(
+              book.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: AppTextStyles.body1Bold,
+            ),
+
+            Text(
+              book.author,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTextStyles.body2Regular.copyWith(color: colors.textSecondary),
+            ),
+            const SizedBox(height: 6),
+            if (showStars) ...[
+              Row(
+                children: [
+                  Icon(Icons.star_rounded, color: colors.primary, size: 16),
+                  const SizedBox(width: 4),
+                  Text(info?.isbn13 != null ? '4.8' : '–', style: AppTextStyles.body2Regular),
+                ],
+              ),
+              const SizedBox(height: 6),
+            ],
+
+            if (showPercentage) ...[
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: LinearProgressIndicator(
+                  value: 0.5,
+                  backgroundColor: colors.tapEffect,
+                  color: colors.primary,
+                  minHeight: 6,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text('50% read', style: AppTextStyles.caption.copyWith(color: colors.textSecondary)),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/books/presentation/widgets/book_cover_placeholder.dart
+++ b/lib/src/features/books/presentation/widgets/book_cover_placeholder.dart
@@ -1,0 +1,42 @@
+import 'package:book_library/src/core/presentation/extensions/color_ext.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class BookCoverPlaceholder extends StatelessWidget {
+  const BookCoverPlaceholder({super.key, this.isNotFound = false});
+  final bool isNotFound;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colors;
+    final highlight = colors.tapEffect.withAlpha(200);
+    final base = colors.tapEffect;
+
+    return isNotFound
+        ? Stack(
+            alignment: Alignment.center,
+            children: [
+              Icon(Icons.book_outlined, size: 64, color: colors.border),
+              Positioned(
+                right: 2,
+                top: 0,
+                child: Container(
+                  width: 22,
+                  height: 22,
+                  decoration: BoxDecoration(
+                    color: colors.textLight,
+                    shape: BoxShape.circle,
+                    border: Border.all(color: colors.error, width: 2),
+                  ),
+                  child: Icon(Icons.close, size: 14, color: colors.error),
+                ),
+              ),
+            ],
+          )
+        : Shimmer.fromColors(
+            baseColor: base,
+            highlightColor: highlight,
+            child: Center(child: Icon(Icons.book_outlined, size: 64, color: base)),
+          );
+  }
+}

--- a/lib/src/features/books_details/data/datasources/external_catalog_remote_data_source.dart
+++ b/lib/src/features/books_details/data/datasources/external_catalog_remote_data_source.dart
@@ -1,0 +1,3 @@
+abstract class ExternalCatalogRemoteDataSource {
+  Future<Map<String, dynamic>> findByTitleAuthor({required String title, required String author});
+}

--- a/lib/src/features/books_details/data/datasources/external_catalog_remote_data_source_impl.dart
+++ b/lib/src/features/books_details/data/datasources/external_catalog_remote_data_source_impl.dart
@@ -1,0 +1,22 @@
+import 'package:book_library/src/core/constants/api_paths.dart';
+import 'package:book_library/src/features/books_details/data/datasources/external_catalog_remote_data_source.dart';
+import 'package:dio/dio.dart';
+
+class ExternalCatalogRemoteDataSourceImpl implements ExternalCatalogRemoteDataSource {
+  ExternalCatalogRemoteDataSourceImpl(this.dio);
+  final Dio dio;
+
+  String _firstAuthor(String author) => author.split(',').first.trim();
+
+  @override
+  Future<Map<String, dynamic>> findByTitleAuthor({
+    required String title,
+    required String author,
+  }) async {
+    final q = 'intitle:${title.trim()} inauthor:${_firstAuthor(author)}';
+    final params = <String, dynamic>{'q': q, 'maxResults': 1};
+
+    final res = await dio.get(ApiPaths.volumes, queryParameters: params);
+    return res.data as Map<String, dynamic>;
+  }
+}

--- a/lib/src/features/books_details/data/mappers/external_book_info_mapper.dart
+++ b/lib/src/features/books_details/data/mappers/external_book_info_mapper.dart
@@ -1,0 +1,15 @@
+import 'package:book_library/src/features/books_details/data/models/external_book_info_model.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+
+abstract class ExternalBookInfoMapper {
+  static ExternalBookInfoEntity? toEntityOrNull(ExternalCatalogVolumeModel? model) {
+    if (model == null) return null;
+    if (model.title.isEmpty) return null;
+    return ExternalBookInfoEntity(
+      title: model.title,
+      description: model.description,
+      coverUrl: model.coverUrl,
+      isbn13: model.isbn13,
+    );
+  }
+}

--- a/lib/src/features/books_details/data/models/external_book_info_model.dart
+++ b/lib/src/features/books_details/data/models/external_book_info_model.dart
@@ -1,0 +1,46 @@
+class ExternalCatalogVolumeModel {
+  const ExternalCatalogVolumeModel({
+    required this.title,
+    this.description,
+    this.coverUrl,
+    this.isbn13,
+  });
+
+  factory ExternalCatalogVolumeModel.fromRootJson(Map<String, dynamic> json) {
+    final items = (json['items'] as List?) ?? const [];
+    if (items.isEmpty) {
+      return const ExternalCatalogVolumeModel(title: '');
+    }
+    final item = items.first as Map<String, dynamic>;
+    final info = (item['volumeInfo'] as Map?) ?? const {};
+    final images = (info['imageLinks'] as Map?) ?? const {};
+    final idents = (info['industryIdentifiers'] as List?) ?? const [];
+
+    String? isbn13;
+    for (final raw in idents) {
+      final m = (raw as Map);
+      if (m['type'] == 'ISBN_13') {
+        isbn13 = m['identifier'] as String?;
+        break;
+      }
+    }
+    isbn13 ??=
+        (idents.whereType<Map>().firstWhere(
+              (m) => m['type'] == 'ISBN_10',
+              orElse: () => const {},
+            )['identifier']
+            as String?);
+
+    return ExternalCatalogVolumeModel(
+      title: (info['title'] as String?) ?? '',
+      description: info['description'] as String?,
+      coverUrl: (images['thumbnail'] as String?) ?? (images['smallThumbnail'] as String?),
+      isbn13: isbn13,
+    );
+  }
+
+  final String title;
+  final String? description;
+  final String? coverUrl;
+  final String? isbn13;
+}

--- a/lib/src/features/books_details/data/repositories/books_details_repository_impl.dart
+++ b/lib/src/features/books_details/data/repositories/books_details_repository_impl.dart
@@ -1,0 +1,26 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books_details/data/datasources/external_catalog_remote_data_source.dart';
+import 'package:book_library/src/features/books_details/data/mappers/external_book_info_mapper.dart';
+import 'package:book_library/src/features/books_details/data/models/external_book_info_model.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/books_details/domain/repositories/book_details_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class ExternalBookInfoRepositoryImpl implements ExternalBookInfoRepository {
+  ExternalBookInfoRepositoryImpl(this.remote);
+  final ExternalCatalogRemoteDataSource remote;
+
+  @override
+  Future<Either<Failure, ExternalBookInfoEntity?>> resolveByTitleAuthor({
+    required String title,
+    required String author,
+  }) async {
+    try {
+      final json = await remote.findByTitleAuthor(title: title, author: author);
+      final model = ExternalCatalogVolumeModel.fromRootJson(json);
+      return Right(ExternalBookInfoMapper.toEntityOrNull(model));
+    } catch (e, s) {
+      return Left(NetworkFailure('Failed to resolve external book info', cause: e, stackTrace: s));
+    }
+  }
+}

--- a/lib/src/features/books_details/domain/entites/external_book_info_entity.dart
+++ b/lib/src/features/books_details/domain/entites/external_book_info_entity.dart
@@ -1,0 +1,12 @@
+import 'package:equatable/equatable.dart';
+
+class ExternalBookInfoEntity extends Equatable {
+  const ExternalBookInfoEntity({required this.title, this.description, this.coverUrl, this.isbn13});
+  final String title;
+  final String? description;
+  final String? coverUrl;
+  final String? isbn13;
+
+  @override
+  List<Object?> get props => [title, description, coverUrl, isbn13];
+}

--- a/lib/src/features/books_details/domain/repositories/book_details_repository.dart
+++ b/lib/src/features/books_details/domain/repositories/book_details_repository.dart
@@ -1,0 +1,10 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:dartz/dartz.dart';
+
+abstract class ExternalBookInfoRepository {
+  Future<Either<Failure, ExternalBookInfoEntity?>> resolveByTitleAuthor({
+    required String title,
+    required String author,
+  });
+}

--- a/lib/src/features/books_details/domain/use_cases/get_book_details_use_case.dart
+++ b/lib/src/features/books_details/domain/use_cases/get_book_details_use_case.dart
@@ -1,0 +1,24 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/books_details/domain/repositories/book_details_repository.dart';
+import 'package:dartz/dartz.dart';
+
+abstract class GetBookDetailsUseCase {
+  const GetBookDetailsUseCase();
+
+  Future<Either<Failure, ExternalBookInfoEntity?>> call({
+    required String title,
+    required String author,
+  });
+}
+
+class GetBookDetailsUseCaseImpl implements GetBookDetailsUseCase {
+  const GetBookDetailsUseCaseImpl(this.repo);
+  final ExternalBookInfoRepository repo;
+
+  @override
+  Future<Either<Failure, ExternalBookInfoEntity?>> call({
+    required String title,
+    required String author,
+  }) => repo.resolveByTitleAuthor(title: title, author: author);
+}

--- a/lib/src/features/books_details/services/external_book_info_resolver.dart
+++ b/lib/src/features/books_details/services/external_book_info_resolver.dart
@@ -1,0 +1,59 @@
+import 'package:book_library/src/core/services/cache/cache.dart';
+import 'package:book_library/src/core/services/coalescing/inflight_coalescer.dart';
+import 'package:book_library/src/core/services/concurrency/concurrency_limiter.dart';
+import 'package:book_library/src/core/services/key/canonical_key_strategy.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/books_details/domain/use_cases/get_book_details_use_case.dart';
+
+class ExternalBookInfoResolver {
+  ExternalBookInfoResolver({
+    required this.usecase,
+    required this.cache,
+    required this.limiter,
+    required this.coalescer,
+    required this.keyOf,
+  });
+
+  final GetBookDetailsUseCase usecase;
+  final Cache<String, ExternalBookInfoEntity?> cache;
+  final ConcurrencyLimiter limiter;
+  final InflightCoalescer<String, ExternalBookInfoEntity?> coalescer;
+  final CanonicalKeyStrategy keyOf;
+
+  Future<ExternalBookInfoEntity?> resolve(String title, String author) async {
+    final key = keyOf(title, author);
+    final cached = cache.get(key);
+    if (cached != null) return cached;
+
+    return coalescer.run(key, () async {
+      await limiter.acquire();
+      try {
+        final either = await usecase(title: title, author: author);
+        final entity = either.fold((_) => null, (e) => e);
+        if (entity != null) cache.set(key, entity);
+        return entity;
+      } finally {
+        limiter.release();
+      }
+    });
+  }
+
+  Future<void> prefetch(Iterable<({String title, String author})> pairs) async {
+    for (final p in pairs) {
+      final key = keyOf(p.title, p.author);
+      if (cache.get(key) != null) continue;
+
+      coalescer.run(key, () async {
+        await limiter.acquire();
+        try {
+          final either = await usecase(title: p.title, author: p.author);
+          final entity = either.fold((_) => null, (e) => e);
+          if (entity != null) cache.set(key, entity);
+          return entity;
+        } finally {
+          limiter.release();
+        }
+      });
+    }
+  }
+}

--- a/lib/src/features/home/presentation/view_model/home_view_model.dart
+++ b/lib/src/features/home/presentation/view_model/home_view_model.dart
@@ -1,0 +1,90 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/core/state/ui_event.dart';
+import 'package:book_library/src/core/state/view_model_state.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_all_books_use_case.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_categories_use_case.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/books_details/services/external_book_info_resolver.dart';
+import 'package:book_library/src/features/home/presentation/view_model/home_view_model_state.dart';
+import 'package:flutter/foundation.dart';
+
+class HomeViewModel {
+  HomeViewModel(this._getBooks, this._getCategories, this._resolver);
+  final GetAllBooksUseCase _getBooks;
+  final GetCategoriesUseCase _getCategories;
+
+  final ExternalBookInfoResolver _resolver;
+
+  final ValueNotifier<ViewModelState<Failure, HomeData>> state =
+      ValueNotifier<ViewModelState<Failure, HomeData>>(InitialState());
+
+  final ValueNotifier<UiEvent?> event = ValueNotifier<UiEvent?>(null);
+
+  final ValueNotifier<Map<String, ExternalBookInfoEntity>> byBookId = ValueNotifier(
+    <String, ExternalBookInfoEntity>{},
+  );
+
+  Future<void> load() async {
+    state.value = LoadingState();
+
+    final catsEither = await _getCategories();
+    return catsEither.fold(
+      (f) {
+        state.value = ErrorState(f);
+        event.value = ShowErrorSnackBar(f.message);
+      },
+      (cats) async {
+        final booksEither = await _getBooks();
+        booksEither.fold(
+          (f) {
+            state.value = ErrorState(f);
+            event.value = ShowErrorSnackBar(f.message);
+          },
+          (books) {
+            final mid = (books.length / 2).floor();
+            final data = HomeData(
+              categories: cats,
+              activeCategoryId: cats.isNotEmpty ? cats.first.id : null,
+              library: books.take(mid).toList(),
+              explore: books.skip(mid).toList(),
+            );
+            state.value = SuccessState(data);
+
+            _prefetchFor(data.library.take(6));
+            _prefetchFor(data.explore.take(6));
+          },
+        );
+      },
+    );
+  }
+
+  void selectCategory(String id) {
+    final current = state.value;
+    if (current is SuccessState<Failure, HomeData>) {
+      if (current.success.activeCategoryId == id) return;
+      final updated = current.success.copyWith(activeCategoryId: id);
+      state.value = SuccessState(updated);
+
+      _prefetchFor(updated.library.take(6));
+    }
+  }
+
+  Future<void> resolveFor(BookEntity book) async {
+    if (byBookId.value.containsKey(book.id)) return;
+
+    final info = await _resolver.resolve(book.title, book.author);
+    if (info != null) {
+      final next = Map<String, ExternalBookInfoEntity>.from(byBookId.value);
+      next[book.id] = info;
+      byBookId.value = next;
+    }
+  }
+
+  Future<void> _prefetchFor(Iterable<BookEntity> books) async {
+    final pairs = books.map((b) => (title: b.title, author: b.author));
+    await _resolver.prefetch(pairs);
+  }
+
+  void consumeEvent() => event.value = null;
+}

--- a/lib/src/features/home/presentation/view_model/home_view_model_state.dart
+++ b/lib/src/features/home/presentation/view_model/home_view_model_state.dart
@@ -1,0 +1,29 @@
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+
+class HomeData {
+  const HomeData({
+    required this.categories,
+    required this.activeCategoryId,
+    required this.library,
+    required this.explore,
+  });
+  final List<CategoryEntity> categories;
+  final String? activeCategoryId;
+  final List<BookEntity> library;
+  final List<BookEntity> explore;
+
+  HomeData copyWith({
+    List<CategoryEntity>? categories,
+    String? activeCategoryId,
+    List<BookEntity>? library,
+    List<BookEntity>? explore,
+  }) {
+    return HomeData(
+      categories: categories ?? this.categories,
+      activeCategoryId: activeCategoryId ?? this.activeCategoryId,
+      library: library ?? this.library,
+      explore: explore ?? this.explore,
+    );
+  }
+}

--- a/lib/src/features/home/presentation/widgets/category_chips.dart
+++ b/lib/src/features/home/presentation/widgets/category_chips.dart
@@ -1,0 +1,54 @@
+import 'package:book_library/src/core/presentation/extensions/color_ext.dart';
+import 'package:book_library/src/core/theme/app_text_styles.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+import 'package:flutter/material.dart';
+
+class CategoryChips extends StatelessWidget {
+  const CategoryChips({
+    super.key,
+    required this.items,
+    required this.activeId,
+    required this.onTap,
+  });
+
+  final List<CategoryEntity> items;
+  final String? activeId;
+  final void Function(String id) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colors;
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+      child: Row(
+        children: items.map((c) {
+          final active = c.id == activeId;
+          return Padding(
+            padding: const EdgeInsets.only(right: 12),
+            child: InkWell(
+              borderRadius: BorderRadius.circular(24),
+              onTap: () => onTap(c.id),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
+                decoration: BoxDecoration(
+                  color: active ? colors.selectionEffect : colors.surface,
+                  borderRadius: BorderRadius.circular(24),
+                  border: Border.all(color: colors.border),
+                ),
+                child: Text(
+                  c.name,
+                  style: AppTextStyles.body2Regular.copyWith(
+                    color: active ? colors.primaryDark : colors.textPrimary,
+                    fontWeight: active ? FontWeight.w600 : FontWeight.w400,
+                  ),
+                ),
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}

--- a/lib/src/features/home/presentation/widgets/home_skeleton.dart
+++ b/lib/src/features/home/presentation/widgets/home_skeleton.dart
@@ -1,0 +1,134 @@
+import 'package:book_library/src/core/presentation/extensions/color_ext.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class HomeSkeleton extends StatelessWidget {
+  const HomeSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colors;
+
+    Widget skeletonBox({
+      double? width,
+      double? height,
+      BorderRadius? radius,
+      EdgeInsetsGeometry? margin,
+      BoxBorder? border,
+    }) {
+      final base = colors.tapEffect;
+      final highlight = colors.tapEffect.withAlpha(200);
+
+      return Shimmer.fromColors(
+        baseColor: base,
+        highlightColor: highlight,
+        child: Container(
+          width: width,
+          height: height,
+          margin: margin,
+          decoration: BoxDecoration(
+            color: base,
+            borderRadius: radius ?? BorderRadius.circular(8),
+            border: border,
+          ),
+        ),
+      );
+    }
+
+    Widget chip() => skeletonBox(
+      width: 90,
+      height: 36,
+      margin: const EdgeInsets.only(right: 12),
+      radius: BorderRadius.circular(24),
+      border: Border.all(color: colors.border),
+    );
+
+    Widget card() => Container(
+      width: 220,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: colors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          skeletonBox(height: 260, radius: BorderRadius.circular(12)),
+          const SizedBox(height: 12),
+          skeletonBox(height: 14, width: 160),
+          const SizedBox(height: 8),
+          skeletonBox(height: 12, width: 100),
+        ],
+      ),
+    );
+
+    return ListView(
+      children: [
+        const SizedBox(height: 8),
+
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+          child: Row(children: List.generate(5, (_) => chip())),
+        ),
+
+        const SizedBox(height: 8),
+
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              skeletonBox(height: 28, width: 120, radius: BorderRadius.circular(6)),
+              skeletonBox(height: 16, width: 60, radius: BorderRadius.circular(6)),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+
+        SizedBox(
+          height: 424,
+          width: 220,
+          child: ListView.separated(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            scrollDirection: Axis.horizontal,
+            itemBuilder: (_, __) => card(),
+            separatorBuilder: (_, __) => const SizedBox(width: 16),
+            itemCount: 3,
+          ),
+        ),
+
+        const SizedBox(height: 16),
+
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              skeletonBox(height: 28, width: 120, radius: BorderRadius.circular(6)),
+              const SizedBox(height: 8),
+              skeletonBox(height: 14, width: 240, radius: BorderRadius.circular(6)),
+            ],
+          ),
+        ),
+
+        const SizedBox(height: 12),
+
+        SizedBox(
+          height: 424,
+          width: 220,
+          child: ListView.separated(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            scrollDirection: Axis.horizontal,
+            itemBuilder: (_, __) => card(),
+            separatorBuilder: (_, __) => const SizedBox(width: 16),
+            itemCount: 3,
+          ),
+        ),
+
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+}

--- a/lib/src/features/home/presentation/widgets/horizontal_books_list.dart
+++ b/lib/src/features/home/presentation/widgets/horizontal_books_list.dart
@@ -1,0 +1,54 @@
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/presentation/widgets/book_card.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class HorizontalBooksList extends StatelessWidget {
+  const HorizontalBooksList({
+    super.key,
+    required this.list,
+    required this.resolveFor,
+    required this.byBookId,
+    this.showPercentage = true,
+    this.showStars = true,
+  });
+
+  final Future<void> Function(BookEntity book) resolveFor;
+  final ValueListenable<Map<String, ExternalBookInfoEntity>> byBookId;
+  final List<BookEntity> list;
+  final bool showPercentage;
+  final bool showStars;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 424,
+      child: ListView.separated(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        scrollDirection: Axis.horizontal,
+        itemCount: list.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 16),
+        itemBuilder: (_, i) {
+          final book = list[i];
+
+          resolveFor(book);
+
+          return ValueListenableBuilder<Map<String, ExternalBookInfoEntity>>(
+            valueListenable: byBookId,
+            builder: (_, map, __) {
+              final info = map[book.id];
+              return BookCard(
+                book: book,
+                info: info,
+                onTap: () {},
+                showPercentage: showPercentage,
+                showStars: showStars,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/src/features/home/presentation/widgets/section_header.dart
+++ b/lib/src/features/home/presentation/widgets/section_header.dart
@@ -1,0 +1,47 @@
+import 'package:book_library/src/core/presentation/extensions/color_ext.dart';
+import 'package:book_library/src/core/theme/app_text_styles.dart';
+import 'package:flutter/material.dart';
+
+class SectionHeader extends StatelessWidget {
+  const SectionHeader({super.key, required this.title, this.action, this.onTap, this.subtitle})
+    : assert((action == null && onTap == null) || (action != null && onTap != null));
+  final String title;
+  final String? subtitle;
+  final String? action;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Expanded(child: Text(title, style: AppTextStyles.h5)),
+              if (onTap != null && action != null)
+                GestureDetector(
+                  onTap: onTap,
+                  child: Text(
+                    action!,
+                    style: AppTextStyles.body2Regular.copyWith(color: colors.textSecondary),
+                  ),
+                ),
+            ],
+          ),
+          if (subtitle != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Text(
+                subtitle!,
+                style: AppTextStyles.body2Regular.copyWith(color: colors.textSecondary),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,6 +161,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.1"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   equatable:
     dependency: "direct main"
     description:
@@ -206,6 +222,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: d4130c4a43e0b13fefc593bc3961f2cb46e30cb79e253d4a526b1b5d24ae1ce4
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -541,6 +565,14 @@ packages:
     description:
       name: shelf_web_socket
       sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  shimmer:
+    dependency: "direct main"
+    description:
+      name: shimmer
+      sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,11 @@ dependencies:
   intl: ^0.20.2
   shared_preferences: ^2.5.3
   dartz: ^0.10.1
+  shimmer: ^3.0.0
+  dio: ^5.9.0
+  flutter_dotenv: ^6.0.0
+  
+  
 
 dev_dependencies:
   flutter_test:
@@ -31,6 +36,7 @@ flutter:
     - assets/fonts/montserrat/
     - assets/fonts/roboto/
     - assets/images/
+    - .env
 
   fonts:
     - family: Roboto

--- a/test/core/services/cache/lru_cache_test.dart
+++ b/test/core/services/cache/lru_cache_test.dart
@@ -1,0 +1,34 @@
+import 'package:book_library/src/core/services/cache/lru_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('get move o item para mais recente', () {
+    final cache = LruCache<String, int>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    expect(cache.keys.toList(), ['a', 'b']);
+
+    expect(cache.get('a'), 1);
+    expect(cache.keys.toList(), ['b', 'a']);
+  });
+
+  test('estoura capacidade remove o menos recente', () {
+    final cache = LruCache<String, int>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    cache.set('c', 3);
+    expect(cache.keys.toList(), ['b', 'c']);
+    expect(cache.get('a'), isNull);
+  });
+
+  test('overwrite atualiza e move para mais recente', () {
+    final cache = LruCache<String, int>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('a', 42);
+    expect(cache.get('a'), 42);
+    expect(cache.keys.last, 'a');
+  });
+}

--- a/test/core/services/coalescing/map_inflight_coalescer_test.dart
+++ b/test/core/services/coalescing/map_inflight_coalescer_test.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import 'package:book_library/src/core/services/coalescing/inflight_coalescer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class MapInflightCoalescer<K, V> implements InflightCoalescer<K, V> {
+  final _inflight = <K, Future<V>>{};
+  @override
+  Future<V> run(K key, Future<V> Function() task) {
+    final existing = _inflight[key];
+    if (existing != null) return existing;
+    final future = task();
+    _inflight[key] = future;
+    return future.whenComplete(() => _inflight.remove(key));
+  }
+}
+
+void main() {
+  group('MapInflightCoalescer', () {
+    test('coalesces chamadas simultâneas com a mesma chave', () async {
+      final c = MapInflightCoalescer<String, int>();
+      final completer = Completer<int>();
+      var calls = 0;
+
+      Future<int> task() async {
+        calls++;
+        return completer.future;
+      }
+
+      final f1 = c.run('k', task);
+      final f2 = c.run('k', task);
+
+      expect(calls, 1);
+
+      completer.complete(42);
+
+      final r1 = await f1;
+      final r2 = await f2;
+
+      expect(r1, 42);
+      expect(r2, 42);
+      expect(calls, 1);
+    });
+
+    test('depois que completa, nova chamada dispara novo task', () async {
+      final c = MapInflightCoalescer<String, int>();
+
+      var calls = 0;
+      Future<int> taskOnce(int value) async {
+        calls++;
+        return value;
+      }
+
+      final r1 = await c.run('k', () => taskOnce(1));
+      expect(r1, 1);
+      expect(calls, 1);
+
+      final r2 = await c.run('k', () => taskOnce(2));
+      expect(r2, 2);
+      expect(calls, 2);
+    });
+
+    test('propaga erro para todos os aguardando e limpa inflight', () async {
+      final c = MapInflightCoalescer<String, int>();
+      final completer = Completer<int>();
+      var calls = 0;
+
+      Future<int> task() async {
+        calls++;
+        return completer.future;
+      }
+
+      final f1 = c.run('k', task);
+      final f2 = c.run('k', task);
+      expect(calls, 1);
+
+      completer.completeError(StateError('boom'));
+
+      await expectLater(f1, throwsA(isA<StateError>()));
+      await expectLater(f2, throwsA(isA<StateError>()));
+
+      final r3 = await c.run('k', () async => 5);
+      expect(r3, 5);
+    });
+  });
+}

--- a/test/features/books/data/datasource/books_remote_data_source_impl_test.dart
+++ b/test/features/books/data/datasource/books_remote_data_source_impl_test.dart
@@ -1,0 +1,39 @@
+import 'package:book_library/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source_impl.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockDio dio;
+  late BooksRemoteDataSourceImpl ds;
+
+  setUp(() {
+    dio = MockDio();
+    ds = BooksRemoteDataSourceImpl(dio);
+  });
+
+  test('fetchBooks retorna lista de maps', () async {
+    final data = [
+      {'id': '1', 'title': 'A', 'author': 'X', 'published': '2020-01-01', 'publisher': 'P'},
+    ];
+    when(dio.get(any)).thenAnswer(
+      (_) async => Response(
+        requestOptions: RequestOptions(path: '/'),
+        data: data,
+        statusCode: 200,
+      ),
+    );
+
+    final res = await ds.fetchBooks();
+    expect(res, isA<List<Map<String, dynamic>>>());
+    expect(res.length, 1);
+    expect(res.first['title'], 'A');
+  });
+
+  test('fetchBooks propaga exceção do dio', () async {
+    when(dio.get(any)).thenThrow(DioException(requestOptions: RequestOptions(path: '/')));
+    expect(() => ds.fetchBooks(), throwsA(isA<DioException>()));
+  });
+}

--- a/test/features/books/data/datasource/categories_fake_data_source_impl_test.dart
+++ b/test/features/books/data/datasource/categories_fake_data_source_impl_test.dart
@@ -1,0 +1,11 @@
+import 'package:book_library/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('fetchCategories retorna cinco categorias padrão', () async {
+    final ds = CategoriesFakeDataSourceImpl();
+    final res = await ds.fetchCategories();
+    expect(res.length, 5);
+    expect(res.first['name'], isNotEmpty);
+  });
+}

--- a/test/features/books/data/repositories/books_repository_impl_test.dart
+++ b/test/features/books/data/repositories/books_repository_impl_test.dart
@@ -1,0 +1,71 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/data/repositories/books_repository_impl.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockBooksRemoteDataSource remote;
+  late BooksRepositoryImpl repo;
+
+  setUp(() {
+    remote = MockBooksRemoteDataSource();
+    repo = BooksRepositoryImpl(remote);
+  });
+
+  final raw = [
+    {
+      'id': '1',
+      'title': 'The Lean Startup',
+      'author': 'Eric Ries',
+      'published': '2011-09-13',
+      'publisher': 'Crown Business',
+    },
+    {
+      'id': '2',
+      'title': 'De Zero a Um',
+      'author': 'Peter Thiel',
+      'published': '2014-09-16',
+      'publisher': 'Objetiva',
+    },
+  ];
+
+  test('getAll mapeia para entidades', () async {
+    when(remote.fetchBooks()).thenAnswer((_) async => raw);
+
+    final res = await repo.getAll();
+    expect(res.isRight(), true);
+    res.fold((_) {}, (list) {
+      expect(list, isA<List<BookEntity>>());
+      expect(list.length, 2);
+      expect(list.first.title, 'The Lean Startup');
+    });
+  });
+
+  test('searchByTitle filtra por título case-insensitive', () async {
+    when(remote.fetchBooks()).thenAnswer((_) async => raw);
+
+    final res = await repo.searchByTitle('zero');
+    expect(res.isRight(), true);
+    res.fold((_) {}, (list) {
+      expect(list.length, 1);
+      expect(list.first.title, 'De Zero a Um');
+    });
+  });
+
+  test('getAll retorna Left em erro do datasource', () async {
+    when(remote.fetchBooks()).thenThrow(Exception('boom'));
+    final res = await repo.getAll();
+    expect(res.isLeft(), true);
+    res.fold((f) => expect(f, isA<NetworkFailure>()), (_) {});
+  });
+
+  test('searchByTitle retorna Left em erro do datasource', () async {
+    when(remote.fetchBooks()).thenThrow(Exception('boom'));
+    final res = await repo.searchByTitle('x');
+    expect(res.isLeft(), true);
+    res.fold((f) => expect(f, isA<NetworkFailure>()), (_) {});
+  });
+}

--- a/test/features/books/data/repositories/categories_repository_impl_test.dart
+++ b/test/features/books/data/repositories/categories_repository_impl_test.dart
@@ -1,0 +1,40 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/data/repositories/categories_repository_impl.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockCategoriesFakeDataSource ds;
+  late CategoriesRepositoryImpl repo;
+
+  setUp(() {
+    ds = MockCategoriesFakeDataSource();
+    repo = CategoriesRepositoryImpl(ds);
+  });
+
+  test('getAll retorna entidades ao sucesso', () async {
+    when(ds.fetchCategories()).thenAnswer(
+      (_) async => [
+        {'id': '1', 'name': 'Romance'},
+        {'id': '2', 'name': 'Fantasy'},
+      ],
+    );
+
+    final res = await repo.getAll();
+    expect(res.isRight(), true);
+    res.fold((_) {}, (list) {
+      expect(list, isA<List<CategoryEntity>>());
+      expect(list.first.name, 'Romance');
+    });
+  });
+
+  test('getAll retorna FakeFailure em exceção do datasource', () async {
+    when(ds.fetchCategories()).thenThrow(Exception('x'));
+    final res = await repo.getAll();
+    expect(res.isLeft(), true);
+    res.fold((f) => expect(f, isA<FakeFailure>()), (_) {});
+  });
+}

--- a/test/features/books/domain/use_cases/get_all_books_use_case_test.dart
+++ b/test/features/books/domain/use_cases/get_all_books_use_case_test.dart
@@ -1,0 +1,31 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_all_books_use_case.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockBooksRepository repo;
+  late GetAllBooksUseCase usecase;
+
+  setUp(() {
+    repo = MockBooksRepository();
+    usecase = GetAllBooksUseCaseImpl(repo);
+  });
+
+  test('delegates to repository.getAll', () async {
+    when(repo.getAll()).thenAnswer((_) async => const Right(<BookEntity>[]));
+    final res = await usecase();
+    expect(res.isRight(), true);
+    verify(repo.getAll()).called(1);
+  });
+
+  test('propaga Left do repository', () async {
+    when(repo.getAll()).thenAnswer((_) async => const Left(NetworkFailure('e')));
+    final res = await usecase();
+    expect(res.isLeft(), true);
+  });
+}

--- a/test/features/books/domain/use_cases/get_book_by_title_use_case_test.dart
+++ b/test/features/books/domain/use_cases/get_book_by_title_use_case_test.dart
@@ -1,0 +1,31 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_book_by_title_use_case.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockBooksRepository repo;
+  late GetBookByTitleUseCase usecase;
+
+  setUp(() {
+    repo = MockBooksRepository();
+    usecase = GetBookByTitleUseCaseImpl(repo);
+  });
+
+  test('delegates to repository.searchByTitle', () async {
+    when(repo.searchByTitle('lean')).thenAnswer((_) async => const Right(<BookEntity>[]));
+    final res = await usecase('lean');
+    expect(res.isRight(), true);
+    verify(repo.searchByTitle('lean')).called(1);
+  });
+
+  test('propaga Left do repository', () async {
+    when(repo.searchByTitle(any)).thenAnswer((_) async => const Left(NetworkFailure('e')));
+    final res = await usecase('x');
+    expect(res.isLeft(), true);
+  });
+}

--- a/test/features/books/domain/use_cases/get_categories_use_case_test.dart
+++ b/test/features/books/domain/use_cases/get_categories_use_case_test.dart
@@ -1,0 +1,31 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_categories_use_case.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockCategoriesRepository repo;
+  late GetCategoriesUseCase usecase;
+
+  setUp(() {
+    repo = MockCategoriesRepository();
+    usecase = GetCategoriesUseCaseImpl(repo);
+  });
+
+  test('delegates to repository.getAll', () async {
+    when(repo.getAll()).thenAnswer((_) async => const Right(<CategoryEntity>[]));
+    final res = await usecase();
+    expect(res.isRight(), true);
+    verify(repo.getAll()).called(1);
+  });
+
+  test('propaga Left do repository', () async {
+    when(repo.getAll()).thenAnswer((_) async => const Left(FakeFailure('x')));
+    final res = await usecase();
+    expect(res.isLeft(), true);
+  });
+}

--- a/test/features/books_detail/data/datasource/external_catalog_remote_data_source_impl_test.dart
+++ b/test/features/books_detail/data/datasource/external_catalog_remote_data_source_impl_test.dart
@@ -1,0 +1,50 @@
+import 'package:book_library/src/core/constants/api_paths.dart';
+import 'package:book_library/src/features/books_details/data/datasources/external_catalog_remote_data_source_impl.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockDio mockDio;
+  late ExternalCatalogRemoteDataSourceImpl ds;
+
+  setUp(() {
+    mockDio = MockDio();
+    ds = ExternalCatalogRemoteDataSourceImpl(mockDio);
+  });
+
+  test('findByTitleAuthor: monta query e retorna json', () async {
+    const title = 'Empreendedorismo Inovador';
+    const author = 'Nei Grando, Outro Nome';
+
+    final fakeResponse = {
+      'kind': 'books#volumes',
+      'items': [
+        {
+          'volumeInfo': {'title': title},
+        },
+      ],
+    };
+
+    when(mockDio.get(ApiPaths.volumes, queryParameters: anyNamed('queryParameters'))).thenAnswer(
+      (_) async => Response(
+        data: fakeResponse,
+        statusCode: 200,
+        requestOptions: RequestOptions(path: ApiPaths.volumes),
+      ),
+    );
+
+    final result = await ds.findByTitleAuthor(title: title, author: author);
+
+    final captured =
+        verify(
+              mockDio.get(ApiPaths.volumes, queryParameters: captureAnyNamed('queryParameters')),
+            ).captured.first
+            as Map<String, dynamic>;
+
+    expect(captured['q'], 'intitle:Empreendedorismo Inovador inauthor:Nei Grando');
+    expect(captured['maxResults'], 1);
+    expect(result['kind'], 'books#volumes');
+  });
+}

--- a/test/features/books_detail/data/repositories/books_details_repository_impl_test.dart
+++ b/test/features/books_detail/data/repositories/books_details_repository_impl_test.dart
@@ -1,0 +1,60 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/features/books_details/data/repositories/books_details_repository_impl.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockExternalCatalogRemoteDataSource mockRemote;
+  late ExternalBookInfoRepositoryImpl repo;
+
+  setUp(() {
+    mockRemote = MockExternalCatalogRemoteDataSource();
+    repo = ExternalBookInfoRepositoryImpl(mockRemote);
+  });
+
+  test('resolveByTitleAuthor: Right(entity) quando JSON válido', () async {
+    when(
+      mockRemote.findByTitleAuthor(title: anyNamed('title'), author: anyNamed('author')),
+    ).thenAnswer(
+      (_) async => {
+        'items': [
+          {
+            'volumeInfo': {
+              'title': 'Gestão de qualidade em saúde',
+              'description': 'desc',
+              'imageLinks': {'thumbnail': 'http://img'},
+              'industryIdentifiers': [
+                {'type': 'ISBN_13', 'identifier': '9786553811072'},
+              ],
+            },
+          },
+        ],
+      },
+    );
+
+    final either = await repo.resolveByTitleAuthor(title: 'x', author: 'y');
+
+    expect(either.isRight(), true);
+    final entity = (either as Right<Failure, ExternalBookInfoEntity?>).value;
+    expect(entity?.title, 'Gestão de qualidade em saúde');
+    expect(entity?.description, 'desc');
+    expect(entity?.coverUrl, 'http://img');
+    expect(entity?.isbn13, '9786553811072');
+  });
+
+  test('resolveByTitleAuthor: Left(NetworkFailure) quando remote lança', () async {
+    when(
+      mockRemote.findByTitleAuthor(title: anyNamed('title'), author: anyNamed('author')),
+    ).thenThrow(Exception('boom'));
+
+    final either = await repo.resolveByTitleAuthor(title: 't', author: 'a');
+
+    expect(either.isLeft(), true);
+    final failure = (either as Left<Failure, dynamic>).value;
+    expect(failure, isA<NetworkFailure>());
+  });
+}

--- a/test/features/books_detail/domain/services/external_book_info_resolver_test.dart
+++ b/test/features/books_detail/domain/services/external_book_info_resolver_test.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/core/services/cache/lru_cache.dart';
+import 'package:book_library/src/core/services/coalescing/inflight_coalescer.dart';
+import 'package:book_library/src/core/services/key/default_canonical_key.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/books_details/services/external_book_info_resolver.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+class MapInflightCoalescer<K, V> implements InflightCoalescer<K, V> {
+  final _inflight = <K, Future<V>>{};
+  @override
+  Future<V> run(K key, Future<V> Function() task) {
+    final existing = _inflight[key];
+    if (existing != null) return existing;
+    final future = task();
+    _inflight[key] = future;
+    return future.whenComplete(() => _inflight.remove(key));
+  }
+}
+
+void main() {
+  late MockGetBookDetailsUseCase mockUsecase;
+  late MockCache<String, ExternalBookInfoEntity?> mockCache;
+  late MockConcurrencyLimiter mockLimiter;
+  late InflightCoalescer<String, ExternalBookInfoEntity?> coalescer;
+  late ExternalBookInfoResolver resolver;
+
+  setUp(() {
+    mockUsecase = MockGetBookDetailsUseCase();
+    mockCache = MockCache<String, ExternalBookInfoEntity?>();
+    mockLimiter = MockConcurrencyLimiter();
+    coalescer = MapInflightCoalescer<String, ExternalBookInfoEntity?>();
+
+    resolver = ExternalBookInfoResolver(
+      usecase: mockUsecase,
+      cache: mockCache,
+      limiter: mockLimiter,
+      coalescer: coalescer,
+      keyOf: DefaultCanonicalKey(),
+    );
+  });
+
+  test('prefetch: ignora itens já em cache e grava os não-cacheados', () async {
+    when(mockCache.get('b1|a1')).thenReturn(const ExternalBookInfoEntity(title: 'x'));
+    when(mockCache.get('b2|a2')).thenReturn(null);
+
+    when(mockLimiter.acquire()).thenAnswer((_) async {});
+    when(mockLimiter.release()).thenReturn(null);
+
+    when(
+      mockUsecase(title: 'B2', author: 'A2'),
+    ).thenAnswer((_) async => const Right(ExternalBookInfoEntity(title: 'b2')));
+
+    await resolver.prefetch([(title: 'B1', author: 'A1'), (title: 'B2', author: 'A2')]);
+
+    await untilCalled(mockCache.set('b2|a2', any as ExternalBookInfoEntity?));
+
+    verify(mockUsecase(title: 'B2', author: 'A2')).called(1);
+    verifyNever(mockUsecase(title: 'B1', author: 'A1'));
+    verify(mockCache.set('b2|a2', const ExternalBookInfoEntity(title: 'b2'))).called(1);
+  });
+  test('resolve coalesce + cache write', () async {
+    final cache = LruCache<String, ExternalBookInfoEntity?>(64);
+
+    resolver = ExternalBookInfoResolver(
+      usecase: mockUsecase,
+      cache: cache,
+      limiter: mockLimiter,
+      coalescer: MapInflightCoalescer<String, ExternalBookInfoEntity?>(),
+      keyOf: DefaultCanonicalKey(),
+    );
+
+    when(mockLimiter.acquire()).thenAnswer((_) async {});
+    when(mockLimiter.release()).thenReturn(null);
+
+    final completer = Completer<Either<Failure, ExternalBookInfoEntity?>>();
+    when(mockUsecase(title: 'T', author: 'A')).thenAnswer((_) => completer.future);
+
+    final f1 = resolver.resolve('T', 'A');
+    final f2 = resolver.resolve('T', 'A');
+
+    await untilCalled(mockUsecase(title: 'T', author: 'A'));
+    verify(mockUsecase(title: 'T', author: 'A')).called(1);
+
+    completer.complete(const Right(ExternalBookInfoEntity(title: 'ok')));
+    final r1 = await f1;
+    final r2 = await f2;
+
+    expect(r1?.title, 'ok');
+    expect(r2?.title, 'ok');
+    expect(cache.get('t|a')?.title, 'ok');
+
+    verify(mockLimiter.acquire()).called(1);
+    verify(mockLimiter.release()).called(1);
+    verifyNoMoreInteractions(mockUsecase);
+  });
+}

--- a/test/features/books_detail/domain/use_cases/get_book_details_use_case_test.dart
+++ b/test/features/books_detail/domain/use_cases/get_book_details_use_case_test.dart
@@ -1,0 +1,35 @@
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/books_details/domain/use_cases/get_book_details_use_case.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockExternalBookInfoRepository mockRepo;
+  late GetBookDetailsUseCase usecase;
+
+  setUp(() {
+    mockRepo = MockExternalBookInfoRepository();
+    usecase = GetBookDetailsUseCaseImpl(mockRepo);
+  });
+
+  test('delegates para o repository', () async {
+    const entity = ExternalBookInfoEntity(
+      title: 't',
+      description: 'd',
+      coverUrl: 'u',
+      isbn13: '978',
+    );
+
+    when(
+      mockRepo.resolveByTitleAuthor(title: 'A', author: 'B'),
+    ).thenAnswer((_) async => const Right(entity));
+
+    final res = await usecase(title: 'A', author: 'B');
+
+    expect(res.isRight(), true);
+    verify(mockRepo.resolveByTitleAuthor(title: 'A', author: 'B')).called(1);
+  });
+}

--- a/test/features/home/presentation/view_model/home_view_model_test.dart
+++ b/test/features/home/presentation/view_model/home_view_model_test.dart
@@ -1,0 +1,147 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/core/state/ui_event.dart';
+import 'package:book_library/src/core/state/view_model_state.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/home/presentation/view_model/home_view_model.dart';
+import 'package:book_library/src/features/home/presentation/view_model/home_view_model_state.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../mocks/mocks.mocks.mocks.dart';
+
+void main() {
+  late MockGetAllBooksUseCase mockGetBooks;
+  late MockGetCategoriesUseCase mockGetCategories;
+  late MockExternalBookInfoResolver mockResolver;
+  late HomeViewModel vm;
+
+  final List<BookEntity> books = List.generate(
+    8,
+    (i) => BookEntity(
+      id: '${i + 1}',
+      title: 'Book $i',
+      author: 'Author $i',
+      published: DateTime(2020, 1, 1),
+      publisher: 'Pub',
+    ),
+  );
+
+  final categories = <CategoryEntity>[
+    const CategoryEntity(id: 'romance', name: 'Romance'),
+    const CategoryEntity(id: 'scifi', name: 'Sci-Fi'),
+  ];
+
+  setUp(() {
+    mockGetBooks = MockGetAllBooksUseCase();
+    mockGetCategories = MockGetCategoriesUseCase();
+    mockResolver = MockExternalBookInfoResolver();
+
+    vm = HomeViewModel(mockGetBooks, mockGetCategories, mockResolver);
+  });
+
+  group('load()', () {
+    test('emite SuccessState e realiza prefetch', () async {
+      when(mockGetCategories.call()).thenAnswer((_) async => Right(categories));
+      when(mockGetBooks.call()).thenAnswer((_) async => Right(books));
+      when(mockResolver.prefetch(any)).thenAnswer((_) async {});
+
+      await vm.load();
+
+      expect(vm.state.value, isA<SuccessState<Failure, HomeData>>());
+      final data = (vm.state.value as SuccessState<Failure, HomeData>).success;
+
+      expect(data.activeCategoryId, categories.first.id);
+
+      expect(data.library.length, books.length ~/ 2);
+      expect(data.explore.length, books.length - data.library.length);
+
+      verify(mockResolver.prefetch(any)).called(2);
+      verifyNoMoreInteractions(mockResolver);
+      expect(vm.event.value, isNull);
+    });
+
+    test('quando falha categorias -> ErrorState + ShowErrorSnackBar', () async {
+      when(
+        mockGetCategories.call(),
+      ).thenAnswer((_) async => const Left(NetworkFailure('cats fail')));
+
+      await vm.load();
+
+      expect(vm.state.value, isA<ErrorState<Failure, HomeData>>());
+      expect(vm.event.value, isA<ShowErrorSnackBar>());
+      expect((vm.event.value as ShowErrorSnackBar).message, 'cats fail');
+
+      verifyNever(mockGetBooks.call());
+    });
+
+    test('quando falha livros -> ErrorState + ShowErrorSnackBar', () async {
+      when(mockGetCategories.call()).thenAnswer((_) async => Right(categories));
+      when(mockGetBooks.call()).thenAnswer((_) async => const Left(NetworkFailure('books fail')));
+
+      await vm.load();
+
+      expect(vm.state.value, isA<ErrorState<Failure, HomeData>>());
+      expect(vm.event.value, isA<ShowErrorSnackBar>());
+      expect((vm.event.value as ShowErrorSnackBar).message, 'books fail');
+    });
+  });
+
+  group('selectCategory()', () {
+    setUp(() async {
+      when(mockGetCategories.call()).thenAnswer((_) async => Right(categories));
+      when(mockGetBooks.call()).thenAnswer((_) async => Right(books));
+      when(mockResolver.prefetch(any)).thenAnswer((_) async {});
+      await vm.load();
+      vm.consumeEvent();
+      clearInteractions(mockResolver);
+    });
+
+    test('atualiza activeCategoryId e prefetch da library', () async {
+      final before = (vm.state.value as SuccessState<Failure, HomeData>).success.activeCategoryId;
+
+      vm.selectCategory(categories.last.id);
+
+      final after = (vm.state.value as SuccessState<Failure, HomeData>).success.activeCategoryId;
+
+      expect(before, isNot(equals(after)));
+      expect(after, categories.last.id);
+      verify(mockResolver.prefetch(any)).called(1);
+    });
+
+    test('não faz nada se escolher a mesma categoria', () async {
+      final current = (vm.state.value as SuccessState<Failure, HomeData>).success.activeCategoryId!;
+      vm.selectCategory(current);
+      verifyNever(mockResolver.prefetch(any));
+    });
+  });
+
+  group('resolveFor()', () {
+    test('resolve e popula byBookId; evita chamadas repetidas', () async {
+      final b = books.first;
+      final info = const ExternalBookInfoEntity(
+        title: 'X',
+        description: 'desc',
+        coverUrl: 'http://example.com/example.jpg',
+        isbn13: '978...',
+      );
+
+      when(mockResolver.resolve(b.title, b.author)).thenAnswer((_) async => info);
+
+      await vm.resolveFor(b);
+      expect(vm.byBookId.value[b.id], info);
+      verify(mockResolver.resolve(b.title, b.author)).called(1);
+
+      await vm.resolveFor(b);
+      verifyNoMoreInteractions(mockResolver);
+    });
+  });
+
+  test('consumeEvent limpa o evento', () {
+    vm.event.value = ShowSuccessSnackBar('ok');
+    vm.consumeEvent();
+    expect(vm.event.value, isNull);
+  });
+}

--- a/test/features/launcher/presentation/view/view_model/launher_view_model_test.dart
+++ b/test/features/launcher/presentation/view/view_model/launher_view_model_test.dart
@@ -50,7 +50,7 @@ void main() {
     });
 
     test('emite ShowErrorSnackBar quando falha', () async {
-      when(mockGetDone()).thenAnswer((_) async => Left(StorageFailure('boom')));
+      when(mockGetDone()).thenAnswer((_) async => const Left(StorageFailure('boom')));
 
       await viewModel.decide();
 

--- a/test/mocks/mocks.mocks.dart
+++ b/test/mocks/mocks.mocks.dart
@@ -1,9 +1,23 @@
+import 'package:book_library/src/core/services/cache/cache.dart';
+import 'package:book_library/src/core/services/coalescing/inflight_coalescer.dart';
+import 'package:book_library/src/core/services/concurrency/concurrency_limiter.dart';
 import 'package:book_library/src/core/storage/wrapper/shared_preferences_wrapper.dart';
+import 'package:book_library/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source.dart';
+import 'package:book_library/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source.dart';
+import 'package:book_library/src/features/books/domain/repositories/books_repository.dart';
+import 'package:book_library/src/features/books/domain/repositories/categories_repository.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_all_books_use_case.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_categories_use_case.dart';
+import 'package:book_library/src/features/books_details/data/datasources/external_catalog_remote_data_source.dart';
+import 'package:book_library/src/features/books_details/domain/repositories/book_details_repository.dart';
+import 'package:book_library/src/features/books_details/domain/use_cases/get_book_details_use_case.dart';
+import 'package:book_library/src/features/books_details/services/external_book_info_resolver.dart';
 import 'package:book_library/src/features/onboard/data/datasources/local_data_source.dart';
 import 'package:book_library/src/features/onboard/domain/repository/onboard_repository.dart';
 import 'package:book_library/src/features/onboard/domain/use_cases/get_onboarding_done_use_case.dart';
 import 'package:book_library/src/features/onboard/domain/use_cases/set_onboarding_done_use_case.dart';
 import 'package:book_library/src/features/onboard/presentation/services/onboard_content_provider.dart';
+import 'package:dio/dio.dart';
 import 'package:mockito/annotations.dart';
 
 @GenerateMocks([
@@ -13,5 +27,19 @@ import 'package:mockito/annotations.dart';
   OnboardContentProvider,
   SetOnboardingDoneUseCase,
   GetOnboardingDoneUseCase,
+  GetAllBooksUseCase,
+  GetCategoriesUseCase,
+  ExternalBookInfoResolver,
+  Dio,
+  ExternalCatalogRemoteDataSource,
+  ExternalBookInfoRepository,
+  GetBookDetailsUseCase,
+  Cache,
+  ConcurrencyLimiter,
+  InflightCoalescer,
+  BooksRemoteDataSource,
+  CategoriesFakeDataSource,
+  BooksRepository,
+  CategoriesRepository,
 ])
 void main() {}

--- a/test/mocks/mocks.mocks.mocks.dart
+++ b/test/mocks/mocks.mocks.mocks.dart
@@ -3,25 +3,66 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i14;
 
-import 'package:book_library/src/core/failures/failures.dart' as _i7;
-import 'package:book_library/src/core/storage/wrapper/shared_preferences_wrapper.dart'
-    as _i3;
-import 'package:book_library/src/features/onboard/data/datasources/local_data_source.dart'
-    as _i5;
-import 'package:book_library/src/features/onboard/domain/repository/onboard_repository.dart'
+import 'package:book_library/src/core/failures/failures.dart' as _i18;
+import 'package:book_library/src/core/services/cache/cache.dart' as _i4;
+import 'package:book_library/src/core/services/coalescing/inflight_coalescer.dart'
     as _i6;
+import 'package:book_library/src/core/services/concurrency/concurrency_limiter.dart'
+    as _i5;
+import 'package:book_library/src/core/services/key/canonical_key_strategy.dart'
+    as _i7;
+import 'package:book_library/src/core/storage/wrapper/shared_preferences_wrapper.dart'
+    as _i15;
+import 'package:book_library/src/features/books/data/datasources/books_remote_data_source/books_remote_data_source.dart'
+    as _i33;
+import 'package:book_library/src/features/books/data/datasources/fake_remote_data_source/categories_fake_data_source.dart'
+    as _i34;
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart'
+    as _i24;
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart'
+    as _i26;
+import 'package:book_library/src/features/books/domain/repositories/books_repository.dart'
+    as _i35;
+import 'package:book_library/src/features/books/domain/repositories/categories_repository.dart'
+    as _i36;
+import 'package:book_library/src/features/books/domain/usecases/get_all_books_use_case.dart'
+    as _i23;
+import 'package:book_library/src/features/books/domain/usecases/get_categories_use_case.dart'
+    as _i25;
+import 'package:book_library/src/features/books_details/data/datasources/external_catalog_remote_data_source.dart'
+    as _i30;
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart'
+    as _i28;
+import 'package:book_library/src/features/books_details/domain/repositories/book_details_repository.dart'
+    as _i31;
+import 'package:book_library/src/features/books_details/domain/use_cases/get_book_details_use_case.dart'
+    as _i3;
+import 'package:book_library/src/features/books_details/services/external_book_info_resolver.dart'
+    as _i27;
+import 'package:book_library/src/features/onboard/data/datasources/local_data_source.dart'
+    as _i16;
+import 'package:book_library/src/features/onboard/domain/repository/onboard_repository.dart'
+    as _i17;
 import 'package:book_library/src/features/onboard/domain/use_cases/get_onboarding_done_use_case.dart'
-    as _i11;
+    as _i22;
 import 'package:book_library/src/features/onboard/domain/use_cases/set_onboarding_done_use_case.dart'
-    as _i10;
+    as _i21;
 import 'package:book_library/src/features/onboard/presentation/models/onboard_slide_ui.dart'
-    as _i9;
+    as _i20;
 import 'package:book_library/src/features/onboard/presentation/services/onboard_content_provider.dart'
-    as _i8;
+    as _i19;
 import 'package:dartz/dartz.dart' as _i2;
+import 'package:dio/src/adapter.dart' as _i10;
+import 'package:dio/src/cancel_token.dart' as _i29;
+import 'package:dio/src/dio.dart' as _i13;
+import 'package:dio/src/dio_mixin.dart' as _i9;
+import 'package:dio/src/options.dart' as _i8;
+import 'package:dio/src/response.dart' as _i12;
+import 'package:dio/src/transformer.dart' as _i11;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i32;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -43,158 +84,1381 @@ class _FakeEither_0<L, R> extends _i1.SmartFake implements _i2.Either<L, R> {
     : super(parent, parentInvocation);
 }
 
+class _FakeGetBookDetailsUseCase_1 extends _i1.SmartFake
+    implements _i3.GetBookDetailsUseCase {
+  _FakeGetBookDetailsUseCase_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeCache_2<K, V> extends _i1.SmartFake implements _i4.Cache<K, V> {
+  _FakeCache_2(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeConcurrencyLimiter_3 extends _i1.SmartFake
+    implements _i5.ConcurrencyLimiter {
+  _FakeConcurrencyLimiter_3(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeInflightCoalescer_4<K, V> extends _i1.SmartFake
+    implements _i6.InflightCoalescer<K, V> {
+  _FakeInflightCoalescer_4(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeCanonicalKeyStrategy_5 extends _i1.SmartFake
+    implements _i7.CanonicalKeyStrategy {
+  _FakeCanonicalKeyStrategy_5(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeBaseOptions_6 extends _i1.SmartFake implements _i8.BaseOptions {
+  _FakeBaseOptions_6(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeInterceptors_7 extends _i1.SmartFake implements _i9.Interceptors {
+  _FakeInterceptors_7(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeHttpClientAdapter_8 extends _i1.SmartFake
+    implements _i10.HttpClientAdapter {
+  _FakeHttpClientAdapter_8(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeTransformer_9 extends _i1.SmartFake implements _i11.Transformer {
+  _FakeTransformer_9(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeResponse_10<T1> extends _i1.SmartFake implements _i12.Response<T1> {
+  _FakeResponse_10(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeDio_11 extends _i1.SmartFake implements _i13.Dio {
+  _FakeDio_11(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeFuture_12<T> extends _i1.SmartFake implements _i14.Future<T> {
+  _FakeFuture_12(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
 /// A class which mocks [KeyValueWrapper].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockKeyValueWrapper extends _i1.Mock implements _i3.KeyValueWrapper {
+class MockKeyValueWrapper extends _i1.Mock implements _i15.KeyValueWrapper {
   MockKeyValueWrapper() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<bool> setString(String? key, String? value) =>
+  _i14.Future<bool> setString(String? key, String? value) =>
       (super.noSuchMethod(
             Invocation.method(#setString, [key, value]),
-            returnValue: _i4.Future<bool>.value(false),
+            returnValue: _i14.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i14.Future<bool>);
 
   @override
   String? getString(String? key) =>
       (super.noSuchMethod(Invocation.method(#getString, [key])) as String?);
 
   @override
-  _i4.Future<bool> remove(String? key) =>
+  _i14.Future<bool> remove(String? key) =>
       (super.noSuchMethod(
             Invocation.method(#remove, [key]),
-            returnValue: _i4.Future<bool>.value(false),
+            returnValue: _i14.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i14.Future<bool>);
 }
 
 /// A class which mocks [OnboardingLocalDataSource].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockOnboardingLocalDataSource extends _i1.Mock
-    implements _i5.OnboardingLocalDataSource {
+    implements _i16.OnboardingLocalDataSource {
   MockOnboardingLocalDataSource() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<bool> isDone() =>
+  _i14.Future<bool> isDone() =>
       (super.noSuchMethod(
             Invocation.method(#isDone, []),
-            returnValue: _i4.Future<bool>.value(false),
+            returnValue: _i14.Future<bool>.value(false),
           )
-          as _i4.Future<bool>);
+          as _i14.Future<bool>);
 
   @override
-  _i4.Future<void> setDone(bool? value) =>
+  _i14.Future<void> setDone(bool? value) =>
       (super.noSuchMethod(
             Invocation.method(#setDone, [value]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
+            returnValue: _i14.Future<void>.value(),
+            returnValueForMissingStub: _i14.Future<void>.value(),
           )
-          as _i4.Future<void>);
+          as _i14.Future<void>);
 }
 
 /// A class which mocks [OnboardingRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockOnboardingRepository extends _i1.Mock
-    implements _i6.OnboardingRepository {
+    implements _i17.OnboardingRepository {
   MockOnboardingRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<_i2.Either<_i7.Failure, bool>> isDone() =>
+  _i14.Future<_i2.Either<_i18.Failure, bool>> isDone() =>
       (super.noSuchMethod(
             Invocation.method(#isDone, []),
-            returnValue: _i4.Future<_i2.Either<_i7.Failure, bool>>.value(
-              _FakeEither_0<_i7.Failure, bool>(
+            returnValue: _i14.Future<_i2.Either<_i18.Failure, bool>>.value(
+              _FakeEither_0<_i18.Failure, bool>(
                 this,
                 Invocation.method(#isDone, []),
               ),
             ),
           )
-          as _i4.Future<_i2.Either<_i7.Failure, bool>>);
+          as _i14.Future<_i2.Either<_i18.Failure, bool>>);
 
   @override
-  _i4.Future<_i2.Either<_i7.Failure, _i2.Unit>> setDone(bool? value) =>
+  _i14.Future<_i2.Either<_i18.Failure, _i2.Unit>> setDone(bool? value) =>
       (super.noSuchMethod(
             Invocation.method(#setDone, [value]),
-            returnValue: _i4.Future<_i2.Either<_i7.Failure, _i2.Unit>>.value(
-              _FakeEither_0<_i7.Failure, _i2.Unit>(
+            returnValue: _i14.Future<_i2.Either<_i18.Failure, _i2.Unit>>.value(
+              _FakeEither_0<_i18.Failure, _i2.Unit>(
                 this,
                 Invocation.method(#setDone, [value]),
               ),
             ),
           )
-          as _i4.Future<_i2.Either<_i7.Failure, _i2.Unit>>);
+          as _i14.Future<_i2.Either<_i18.Failure, _i2.Unit>>);
 }
 
 /// A class which mocks [OnboardContentProvider].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockOnboardContentProvider extends _i1.Mock
-    implements _i8.OnboardContentProvider {
+    implements _i19.OnboardContentProvider {
   MockOnboardContentProvider() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  List<_i9.OnboardSlideUi> slides() =>
+  List<_i20.OnboardSlideUi> slides() =>
       (super.noSuchMethod(
             Invocation.method(#slides, []),
-            returnValue: <_i9.OnboardSlideUi>[],
+            returnValue: <_i20.OnboardSlideUi>[],
           )
-          as List<_i9.OnboardSlideUi>);
+          as List<_i20.OnboardSlideUi>);
 }
 
 /// A class which mocks [SetOnboardingDoneUseCase].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockSetOnboardingDoneUseCase extends _i1.Mock
-    implements _i10.SetOnboardingDoneUseCase {
+    implements _i21.SetOnboardingDoneUseCase {
   MockSetOnboardingDoneUseCase() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<_i2.Either<_i7.Failure, _i2.Unit>> call(bool? value) =>
+  _i14.Future<_i2.Either<_i18.Failure, _i2.Unit>> call(bool? value) =>
       (super.noSuchMethod(
             Invocation.method(#call, [value]),
-            returnValue: _i4.Future<_i2.Either<_i7.Failure, _i2.Unit>>.value(
-              _FakeEither_0<_i7.Failure, _i2.Unit>(
+            returnValue: _i14.Future<_i2.Either<_i18.Failure, _i2.Unit>>.value(
+              _FakeEither_0<_i18.Failure, _i2.Unit>(
                 this,
                 Invocation.method(#call, [value]),
               ),
             ),
           )
-          as _i4.Future<_i2.Either<_i7.Failure, _i2.Unit>>);
+          as _i14.Future<_i2.Either<_i18.Failure, _i2.Unit>>);
 }
 
 /// A class which mocks [GetOnboardingDoneUseCase].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockGetOnboardingDoneUseCase extends _i1.Mock
-    implements _i11.GetOnboardingDoneUseCase {
+    implements _i22.GetOnboardingDoneUseCase {
   MockGetOnboardingDoneUseCase() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<_i2.Either<_i7.Failure, bool>> call() =>
+  _i14.Future<_i2.Either<_i18.Failure, bool>> call() =>
       (super.noSuchMethod(
             Invocation.method(#call, []),
-            returnValue: _i4.Future<_i2.Either<_i7.Failure, bool>>.value(
-              _FakeEither_0<_i7.Failure, bool>(
+            returnValue: _i14.Future<_i2.Either<_i18.Failure, bool>>.value(
+              _FakeEither_0<_i18.Failure, bool>(
                 this,
                 Invocation.method(#call, []),
               ),
             ),
           )
-          as _i4.Future<_i2.Either<_i7.Failure, bool>>);
+          as _i14.Future<_i2.Either<_i18.Failure, bool>>);
+}
+
+/// A class which mocks [GetAllBooksUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGetAllBooksUseCase extends _i1.Mock
+    implements _i23.GetAllBooksUseCase {
+  MockGetAllBooksUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<_i2.Either<_i18.Failure, List<_i24.BookEntity>>> call() =>
+      (super.noSuchMethod(
+            Invocation.method(#call, []),
+            returnValue:
+                _i14.Future<
+                  _i2.Either<_i18.Failure, List<_i24.BookEntity>>
+                >.value(
+                  _FakeEither_0<_i18.Failure, List<_i24.BookEntity>>(
+                    this,
+                    Invocation.method(#call, []),
+                  ),
+                ),
+          )
+          as _i14.Future<_i2.Either<_i18.Failure, List<_i24.BookEntity>>>);
+}
+
+/// A class which mocks [GetCategoriesUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGetCategoriesUseCase extends _i1.Mock
+    implements _i25.GetCategoriesUseCase {
+  MockGetCategoriesUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<_i2.Either<_i18.Failure, List<_i26.CategoryEntity>>> call() =>
+      (super.noSuchMethod(
+            Invocation.method(#call, []),
+            returnValue:
+                _i14.Future<
+                  _i2.Either<_i18.Failure, List<_i26.CategoryEntity>>
+                >.value(
+                  _FakeEither_0<_i18.Failure, List<_i26.CategoryEntity>>(
+                    this,
+                    Invocation.method(#call, []),
+                  ),
+                ),
+          )
+          as _i14.Future<_i2.Either<_i18.Failure, List<_i26.CategoryEntity>>>);
+}
+
+/// A class which mocks [ExternalBookInfoResolver].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockExternalBookInfoResolver extends _i1.Mock
+    implements _i27.ExternalBookInfoResolver {
+  MockExternalBookInfoResolver() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i3.GetBookDetailsUseCase get usecase =>
+      (super.noSuchMethod(
+            Invocation.getter(#usecase),
+            returnValue: _FakeGetBookDetailsUseCase_1(
+              this,
+              Invocation.getter(#usecase),
+            ),
+          )
+          as _i3.GetBookDetailsUseCase);
+
+  @override
+  _i4.Cache<String, _i28.ExternalBookInfoEntity?> get cache =>
+      (super.noSuchMethod(
+            Invocation.getter(#cache),
+            returnValue: _FakeCache_2<String, _i28.ExternalBookInfoEntity?>(
+              this,
+              Invocation.getter(#cache),
+            ),
+          )
+          as _i4.Cache<String, _i28.ExternalBookInfoEntity?>);
+
+  @override
+  _i5.ConcurrencyLimiter get limiter =>
+      (super.noSuchMethod(
+            Invocation.getter(#limiter),
+            returnValue: _FakeConcurrencyLimiter_3(
+              this,
+              Invocation.getter(#limiter),
+            ),
+          )
+          as _i5.ConcurrencyLimiter);
+
+  @override
+  _i6.InflightCoalescer<String, _i28.ExternalBookInfoEntity?> get coalescer =>
+      (super.noSuchMethod(
+            Invocation.getter(#coalescer),
+            returnValue:
+                _FakeInflightCoalescer_4<String, _i28.ExternalBookInfoEntity?>(
+                  this,
+                  Invocation.getter(#coalescer),
+                ),
+          )
+          as _i6.InflightCoalescer<String, _i28.ExternalBookInfoEntity?>);
+
+  @override
+  _i7.CanonicalKeyStrategy get keyOf =>
+      (super.noSuchMethod(
+            Invocation.getter(#keyOf),
+            returnValue: _FakeCanonicalKeyStrategy_5(
+              this,
+              Invocation.getter(#keyOf),
+            ),
+          )
+          as _i7.CanonicalKeyStrategy);
+
+  @override
+  _i14.Future<_i28.ExternalBookInfoEntity?> resolve(
+    String? title,
+    String? author,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#resolve, [title, author]),
+            returnValue: _i14.Future<_i28.ExternalBookInfoEntity?>.value(),
+          )
+          as _i14.Future<_i28.ExternalBookInfoEntity?>);
+
+  @override
+  _i14.Future<void> prefetch(
+    Iterable<({String author, String title})>? pairs,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#prefetch, [pairs]),
+            returnValue: _i14.Future<void>.value(),
+            returnValueForMissingStub: _i14.Future<void>.value(),
+          )
+          as _i14.Future<void>);
+}
+
+/// A class which mocks [Dio].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockDio extends _i1.Mock implements _i13.Dio {
+  MockDio() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i8.BaseOptions get options =>
+      (super.noSuchMethod(
+            Invocation.getter(#options),
+            returnValue: _FakeBaseOptions_6(this, Invocation.getter(#options)),
+          )
+          as _i8.BaseOptions);
+
+  @override
+  _i9.Interceptors get interceptors =>
+      (super.noSuchMethod(
+            Invocation.getter(#interceptors),
+            returnValue: _FakeInterceptors_7(
+              this,
+              Invocation.getter(#interceptors),
+            ),
+          )
+          as _i9.Interceptors);
+
+  @override
+  _i10.HttpClientAdapter get httpClientAdapter =>
+      (super.noSuchMethod(
+            Invocation.getter(#httpClientAdapter),
+            returnValue: _FakeHttpClientAdapter_8(
+              this,
+              Invocation.getter(#httpClientAdapter),
+            ),
+          )
+          as _i10.HttpClientAdapter);
+
+  @override
+  _i11.Transformer get transformer =>
+      (super.noSuchMethod(
+            Invocation.getter(#transformer),
+            returnValue: _FakeTransformer_9(
+              this,
+              Invocation.getter(#transformer),
+            ),
+          )
+          as _i11.Transformer);
+
+  @override
+  set options(_i8.BaseOptions? value) => super.noSuchMethod(
+    Invocation.setter(#options, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  set httpClientAdapter(_i10.HttpClientAdapter? value) => super.noSuchMethod(
+    Invocation.setter(#httpClientAdapter, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  set transformer(_i11.Transformer? value) => super.noSuchMethod(
+    Invocation.setter(#transformer, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void close({bool? force = false}) => super.noSuchMethod(
+    Invocation.method(#close, [], {#force: force}),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  _i14.Future<_i12.Response<T>> head<T>(
+    String? path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #head,
+              [path],
+              {
+                #data: data,
+                #queryParameters: queryParameters,
+                #options: options,
+                #cancelToken: cancelToken,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #head,
+                  [path],
+                  {
+                    #data: data,
+                    #queryParameters: queryParameters,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> headUri<T>(
+    Uri? uri, {
+    Object? data,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #headUri,
+              [uri],
+              {#data: data, #options: options, #cancelToken: cancelToken},
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #headUri,
+                  [uri],
+                  {#data: data, #options: options, #cancelToken: cancelToken},
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> get<T>(
+    String? path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #get,
+              [path],
+              {
+                #data: data,
+                #queryParameters: queryParameters,
+                #options: options,
+                #cancelToken: cancelToken,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #get,
+                  [path],
+                  {
+                    #data: data,
+                    #queryParameters: queryParameters,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> getUri<T>(
+    Uri? uri, {
+    Object? data,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #getUri,
+              [uri],
+              {
+                #data: data,
+                #options: options,
+                #cancelToken: cancelToken,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #getUri,
+                  [uri],
+                  {
+                    #data: data,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> post<T>(
+    String? path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+    _i8.ProgressCallback? onSendProgress,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #post,
+              [path],
+              {
+                #data: data,
+                #queryParameters: queryParameters,
+                #options: options,
+                #cancelToken: cancelToken,
+                #onSendProgress: onSendProgress,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #post,
+                  [path],
+                  {
+                    #data: data,
+                    #queryParameters: queryParameters,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                    #onSendProgress: onSendProgress,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> postUri<T>(
+    Uri? uri, {
+    Object? data,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+    _i8.ProgressCallback? onSendProgress,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #postUri,
+              [uri],
+              {
+                #data: data,
+                #options: options,
+                #cancelToken: cancelToken,
+                #onSendProgress: onSendProgress,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #postUri,
+                  [uri],
+                  {
+                    #data: data,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                    #onSendProgress: onSendProgress,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> put<T>(
+    String? path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+    _i8.ProgressCallback? onSendProgress,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #put,
+              [path],
+              {
+                #data: data,
+                #queryParameters: queryParameters,
+                #options: options,
+                #cancelToken: cancelToken,
+                #onSendProgress: onSendProgress,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #put,
+                  [path],
+                  {
+                    #data: data,
+                    #queryParameters: queryParameters,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                    #onSendProgress: onSendProgress,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> putUri<T>(
+    Uri? uri, {
+    Object? data,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+    _i8.ProgressCallback? onSendProgress,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #putUri,
+              [uri],
+              {
+                #data: data,
+                #options: options,
+                #cancelToken: cancelToken,
+                #onSendProgress: onSendProgress,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #putUri,
+                  [uri],
+                  {
+                    #data: data,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                    #onSendProgress: onSendProgress,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> patch<T>(
+    String? path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+    _i8.ProgressCallback? onSendProgress,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #patch,
+              [path],
+              {
+                #data: data,
+                #queryParameters: queryParameters,
+                #options: options,
+                #cancelToken: cancelToken,
+                #onSendProgress: onSendProgress,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #patch,
+                  [path],
+                  {
+                    #data: data,
+                    #queryParameters: queryParameters,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                    #onSendProgress: onSendProgress,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> patchUri<T>(
+    Uri? uri, {
+    Object? data,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+    _i8.ProgressCallback? onSendProgress,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #patchUri,
+              [uri],
+              {
+                #data: data,
+                #options: options,
+                #cancelToken: cancelToken,
+                #onSendProgress: onSendProgress,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #patchUri,
+                  [uri],
+                  {
+                    #data: data,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                    #onSendProgress: onSendProgress,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> delete<T>(
+    String? path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #delete,
+              [path],
+              {
+                #data: data,
+                #queryParameters: queryParameters,
+                #options: options,
+                #cancelToken: cancelToken,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #delete,
+                  [path],
+                  {
+                    #data: data,
+                    #queryParameters: queryParameters,
+                    #options: options,
+                    #cancelToken: cancelToken,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> deleteUri<T>(
+    Uri? uri, {
+    Object? data,
+    _i8.Options? options,
+    _i29.CancelToken? cancelToken,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #deleteUri,
+              [uri],
+              {#data: data, #options: options, #cancelToken: cancelToken},
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #deleteUri,
+                  [uri],
+                  {#data: data, #options: options, #cancelToken: cancelToken},
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<dynamic>> download(
+    String? urlPath,
+    dynamic savePath, {
+    _i8.ProgressCallback? onReceiveProgress,
+    Map<String, dynamic>? queryParameters,
+    _i29.CancelToken? cancelToken,
+    bool? deleteOnError = true,
+    _i8.FileAccessMode? fileAccessMode = _i8.FileAccessMode.write,
+    String? lengthHeader = 'content-length',
+    Object? data,
+    _i8.Options? options,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #download,
+              [urlPath, savePath],
+              {
+                #onReceiveProgress: onReceiveProgress,
+                #queryParameters: queryParameters,
+                #cancelToken: cancelToken,
+                #deleteOnError: deleteOnError,
+                #fileAccessMode: fileAccessMode,
+                #lengthHeader: lengthHeader,
+                #data: data,
+                #options: options,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<dynamic>>.value(
+              _FakeResponse_10<dynamic>(
+                this,
+                Invocation.method(
+                  #download,
+                  [urlPath, savePath],
+                  {
+                    #onReceiveProgress: onReceiveProgress,
+                    #queryParameters: queryParameters,
+                    #cancelToken: cancelToken,
+                    #deleteOnError: deleteOnError,
+                    #fileAccessMode: fileAccessMode,
+                    #lengthHeader: lengthHeader,
+                    #data: data,
+                    #options: options,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<dynamic>>);
+
+  @override
+  _i14.Future<_i12.Response<dynamic>> downloadUri(
+    Uri? uri,
+    dynamic savePath, {
+    _i8.ProgressCallback? onReceiveProgress,
+    _i29.CancelToken? cancelToken,
+    bool? deleteOnError = true,
+    _i8.FileAccessMode? fileAccessMode = _i8.FileAccessMode.write,
+    String? lengthHeader = 'content-length',
+    Object? data,
+    _i8.Options? options,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #downloadUri,
+              [uri, savePath],
+              {
+                #onReceiveProgress: onReceiveProgress,
+                #cancelToken: cancelToken,
+                #deleteOnError: deleteOnError,
+                #fileAccessMode: fileAccessMode,
+                #lengthHeader: lengthHeader,
+                #data: data,
+                #options: options,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<dynamic>>.value(
+              _FakeResponse_10<dynamic>(
+                this,
+                Invocation.method(
+                  #downloadUri,
+                  [uri, savePath],
+                  {
+                    #onReceiveProgress: onReceiveProgress,
+                    #cancelToken: cancelToken,
+                    #deleteOnError: deleteOnError,
+                    #fileAccessMode: fileAccessMode,
+                    #lengthHeader: lengthHeader,
+                    #data: data,
+                    #options: options,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<dynamic>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> request<T>(
+    String? url, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    _i29.CancelToken? cancelToken,
+    _i8.Options? options,
+    _i8.ProgressCallback? onSendProgress,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #request,
+              [url],
+              {
+                #data: data,
+                #queryParameters: queryParameters,
+                #cancelToken: cancelToken,
+                #options: options,
+                #onSendProgress: onSendProgress,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #request,
+                  [url],
+                  {
+                    #data: data,
+                    #queryParameters: queryParameters,
+                    #cancelToken: cancelToken,
+                    #options: options,
+                    #onSendProgress: onSendProgress,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> requestUri<T>(
+    Uri? uri, {
+    Object? data,
+    _i29.CancelToken? cancelToken,
+    _i8.Options? options,
+    _i8.ProgressCallback? onSendProgress,
+    _i8.ProgressCallback? onReceiveProgress,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #requestUri,
+              [uri],
+              {
+                #data: data,
+                #cancelToken: cancelToken,
+                #options: options,
+                #onSendProgress: onSendProgress,
+                #onReceiveProgress: onReceiveProgress,
+              },
+            ),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(
+                  #requestUri,
+                  [uri],
+                  {
+                    #data: data,
+                    #cancelToken: cancelToken,
+                    #options: options,
+                    #onSendProgress: onSendProgress,
+                    #onReceiveProgress: onReceiveProgress,
+                  },
+                ),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i14.Future<_i12.Response<T>> fetch<T>(_i8.RequestOptions? requestOptions) =>
+      (super.noSuchMethod(
+            Invocation.method(#fetch, [requestOptions]),
+            returnValue: _i14.Future<_i12.Response<T>>.value(
+              _FakeResponse_10<T>(
+                this,
+                Invocation.method(#fetch, [requestOptions]),
+              ),
+            ),
+          )
+          as _i14.Future<_i12.Response<T>>);
+
+  @override
+  _i13.Dio clone({
+    _i8.BaseOptions? options,
+    _i9.Interceptors? interceptors,
+    _i10.HttpClientAdapter? httpClientAdapter,
+    _i11.Transformer? transformer,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#clone, [], {
+              #options: options,
+              #interceptors: interceptors,
+              #httpClientAdapter: httpClientAdapter,
+              #transformer: transformer,
+            }),
+            returnValue: _FakeDio_11(
+              this,
+              Invocation.method(#clone, [], {
+                #options: options,
+                #interceptors: interceptors,
+                #httpClientAdapter: httpClientAdapter,
+                #transformer: transformer,
+              }),
+            ),
+          )
+          as _i13.Dio);
+}
+
+/// A class which mocks [ExternalCatalogRemoteDataSource].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockExternalCatalogRemoteDataSource extends _i1.Mock
+    implements _i30.ExternalCatalogRemoteDataSource {
+  MockExternalCatalogRemoteDataSource() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<Map<String, dynamic>> findByTitleAuthor({
+    required String? title,
+    required String? author,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#findByTitleAuthor, [], {
+              #title: title,
+              #author: author,
+            }),
+            returnValue: _i14.Future<Map<String, dynamic>>.value(
+              <String, dynamic>{},
+            ),
+          )
+          as _i14.Future<Map<String, dynamic>>);
+}
+
+/// A class which mocks [ExternalBookInfoRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockExternalBookInfoRepository extends _i1.Mock
+    implements _i31.ExternalBookInfoRepository {
+  MockExternalBookInfoRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<_i2.Either<_i18.Failure, _i28.ExternalBookInfoEntity?>>
+  resolveByTitleAuthor({required String? title, required String? author}) =>
+      (super.noSuchMethod(
+            Invocation.method(#resolveByTitleAuthor, [], {
+              #title: title,
+              #author: author,
+            }),
+            returnValue:
+                _i14.Future<
+                  _i2.Either<_i18.Failure, _i28.ExternalBookInfoEntity?>
+                >.value(
+                  _FakeEither_0<_i18.Failure, _i28.ExternalBookInfoEntity?>(
+                    this,
+                    Invocation.method(#resolveByTitleAuthor, [], {
+                      #title: title,
+                      #author: author,
+                    }),
+                  ),
+                ),
+          )
+          as _i14.Future<
+            _i2.Either<_i18.Failure, _i28.ExternalBookInfoEntity?>
+          >);
+}
+
+/// A class which mocks [GetBookDetailsUseCase].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGetBookDetailsUseCase extends _i1.Mock
+    implements _i3.GetBookDetailsUseCase {
+  MockGetBookDetailsUseCase() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<_i2.Either<_i18.Failure, _i28.ExternalBookInfoEntity?>> call({
+    required String? title,
+    required String? author,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#call, [], {#title: title, #author: author}),
+            returnValue:
+                _i14.Future<
+                  _i2.Either<_i18.Failure, _i28.ExternalBookInfoEntity?>
+                >.value(
+                  _FakeEither_0<_i18.Failure, _i28.ExternalBookInfoEntity?>(
+                    this,
+                    Invocation.method(#call, [], {
+                      #title: title,
+                      #author: author,
+                    }),
+                  ),
+                ),
+          )
+          as _i14.Future<
+            _i2.Either<_i18.Failure, _i28.ExternalBookInfoEntity?>
+          >);
+}
+
+/// A class which mocks [Cache].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockCache<K, V> extends _i1.Mock implements _i4.Cache<K, V> {
+  MockCache() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  V? get(K? key) => (super.noSuchMethod(Invocation.method(#get, [key])) as V?);
+
+  @override
+  void set(K? key, V? value) => super.noSuchMethod(
+    Invocation.method(#set, [key, value]),
+    returnValueForMissingStub: null,
+  );
+}
+
+/// A class which mocks [ConcurrencyLimiter].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockConcurrencyLimiter extends _i1.Mock
+    implements _i5.ConcurrencyLimiter {
+  MockConcurrencyLimiter() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<void> acquire() =>
+      (super.noSuchMethod(
+            Invocation.method(#acquire, []),
+            returnValue: _i14.Future<void>.value(),
+            returnValueForMissingStub: _i14.Future<void>.value(),
+          )
+          as _i14.Future<void>);
+
+  @override
+  void release() => super.noSuchMethod(
+    Invocation.method(#release, []),
+    returnValueForMissingStub: null,
+  );
+}
+
+/// A class which mocks [InflightCoalescer].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockInflightCoalescer<K, V> extends _i1.Mock
+    implements _i6.InflightCoalescer<K, V> {
+  MockInflightCoalescer() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<V> run(K? key, _i14.Future<V> Function()? task) =>
+      (super.noSuchMethod(
+            Invocation.method(#run, [key, task]),
+            returnValue:
+                _i32.ifNotNull(
+                  _i32.dummyValueOrNull<V>(
+                    this,
+                    Invocation.method(#run, [key, task]),
+                  ),
+                  (V v) => _i14.Future<V>.value(v),
+                ) ??
+                _FakeFuture_12<V>(this, Invocation.method(#run, [key, task])),
+          )
+          as _i14.Future<V>);
+}
+
+/// A class which mocks [BooksRemoteDataSource].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockBooksRemoteDataSource extends _i1.Mock
+    implements _i33.BooksRemoteDataSource {
+  MockBooksRemoteDataSource() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<List<Map<String, dynamic>>> fetchBooks() =>
+      (super.noSuchMethod(
+            Invocation.method(#fetchBooks, []),
+            returnValue: _i14.Future<List<Map<String, dynamic>>>.value(
+              <Map<String, dynamic>>[],
+            ),
+          )
+          as _i14.Future<List<Map<String, dynamic>>>);
+}
+
+/// A class which mocks [CategoriesFakeDataSource].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockCategoriesFakeDataSource extends _i1.Mock
+    implements _i34.CategoriesFakeDataSource {
+  MockCategoriesFakeDataSource() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<List<Map<String, dynamic>>> fetchCategories() =>
+      (super.noSuchMethod(
+            Invocation.method(#fetchCategories, []),
+            returnValue: _i14.Future<List<Map<String, dynamic>>>.value(
+              <Map<String, dynamic>>[],
+            ),
+          )
+          as _i14.Future<List<Map<String, dynamic>>>);
+}
+
+/// A class which mocks [BooksRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockBooksRepository extends _i1.Mock implements _i35.BooksRepository {
+  MockBooksRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<_i2.Either<_i18.Failure, List<_i24.BookEntity>>> getAll() =>
+      (super.noSuchMethod(
+            Invocation.method(#getAll, []),
+            returnValue:
+                _i14.Future<
+                  _i2.Either<_i18.Failure, List<_i24.BookEntity>>
+                >.value(
+                  _FakeEither_0<_i18.Failure, List<_i24.BookEntity>>(
+                    this,
+                    Invocation.method(#getAll, []),
+                  ),
+                ),
+          )
+          as _i14.Future<_i2.Either<_i18.Failure, List<_i24.BookEntity>>>);
+
+  @override
+  _i14.Future<_i2.Either<_i18.Failure, List<_i24.BookEntity>>> searchByTitle(
+    String? query,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#searchByTitle, [query]),
+            returnValue:
+                _i14.Future<
+                  _i2.Either<_i18.Failure, List<_i24.BookEntity>>
+                >.value(
+                  _FakeEither_0<_i18.Failure, List<_i24.BookEntity>>(
+                    this,
+                    Invocation.method(#searchByTitle, [query]),
+                  ),
+                ),
+          )
+          as _i14.Future<_i2.Either<_i18.Failure, List<_i24.BookEntity>>>);
+}
+
+/// A class which mocks [CategoriesRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockCategoriesRepository extends _i1.Mock
+    implements _i36.CategoriesRepository {
+  MockCategoriesRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i14.Future<_i2.Either<_i18.Failure, List<_i26.CategoryEntity>>> getAll() =>
+      (super.noSuchMethod(
+            Invocation.method(#getAll, []),
+            returnValue:
+                _i14.Future<
+                  _i2.Either<_i18.Failure, List<_i26.CategoryEntity>>
+                >.value(
+                  _FakeEither_0<_i18.Failure, List<_i26.CategoryEntity>>(
+                    this,
+                    Invocation.method(#getAll, []),
+                  ),
+                ),
+          )
+          as _i14.Future<_i2.Either<_i18.Failure, List<_i26.CategoryEntity>>>);
 }


### PR DESCRIPTION
- Added HomeViewModel with state + UiEvent handling
- Integrated GetAllBooksUseCase and GetCategoriesUseCase
- Connected ExternalBookInfoResolver for cover/details prefetch
- Created BookCard, HomeSkeleton, EmptyState and NoConnection views
- Implemented tests for HomeViewModel, resolvers, repositories, datasources, and use cases
- Added LruCache + InflightCoalescer + DefaultCanonicalKey strategies
- Organized feature structure under /features/home
