### PR TITLE
feat(library): implement Library screen with categories, grid, and resolver

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/src/core/di/injector.dart
+++ b/lib/src/core/di/injector.dart
@@ -29,6 +29,7 @@ import 'package:book_library/src/features/books_details/domain/use_cases/get_boo
 import 'package:book_library/src/features/books_details/services/external_book_info_resolver.dart';
 import 'package:book_library/src/features/home/presentation/view_model/home_view_model.dart';
 import 'package:book_library/src/features/launcher/presentation/view_model/launcher_view_model.dart';
+import 'package:book_library/src/features/library/presentation/view_model/library_view_model.dart';
 import 'package:book_library/src/features/onboard/data/datasources/local_data_source.dart';
 import 'package:book_library/src/features/onboard/data/datasources/local_data_source_impl.dart';
 import 'package:book_library/src/features/onboard/data/repositories/onboard_repository_impl.dart';
@@ -79,13 +80,16 @@ Future<void> setupInjector() async {
 
   /// -------------Onboard-------------------
   getIt.registerLazySingleton<OnboardContentProvider>(() => OnboardContentStatic());
-  getIt.registerFactory<OnboardViewModel>(() => OnboardViewModel(getIt(), getIt()));
+  getIt.registerLazySingleton<OnboardViewModel>(() => OnboardViewModel(getIt(), getIt()));
 
   /// --------------Launcher-----------------
-  getIt.registerFactory<LauncherViewModel>(() => LauncherViewModel(getIt()));
+  getIt.registerLazySingleton<LauncherViewModel>(() => LauncherViewModel(getIt()));
 
   /// ----------------Home-------------------
-  getIt.registerFactory<HomeViewModel>(() => HomeViewModel(getIt(), getIt(), getIt()));
+  getIt.registerLazySingleton<HomeViewModel>(() => HomeViewModel(getIt(), getIt(), getIt()));
+
+  /// ----------------Library-----------------
+  getIt.registerLazySingleton<LibraryViewModel>(() => LibraryViewModel(getIt(), getIt(), getIt()));
 
   /// --------------Use Cases-----------------
   getIt.registerLazySingleton<GetAllBooksUseCase>(() => GetAllBooksUseCaseImpl(getIt()));

--- a/lib/src/core/presentation/widgets/book_library_app_bar.dart
+++ b/lib/src/core/presentation/widgets/book_library_app_bar.dart
@@ -1,0 +1,53 @@
+import 'package:book_library/src/core/presentation/extensions/color_ext.dart';
+import 'package:flutter/material.dart';
+
+class BookLibraryAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const BookLibraryAppBar({
+    super.key,
+    this.showMenu = false,
+    this.showSettings = false,
+    this.showSearch = false,
+    required this.title,
+    this.onMenuTap,
+    this.onSearchTap,
+    this.onSettingsPressed,
+  });
+  final bool showMenu;
+  final VoidCallback? onMenuTap;
+  final VoidCallback? onSearchTap;
+  final bool showSettings;
+  final bool showSearch;
+  final String title;
+  final VoidCallback? onSettingsPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colors;
+    return AppBar(
+      title: Text(title),
+      centerTitle: true,
+      leading: showMenu
+          ? IconButton(
+              icon: Icon(Icons.menu_rounded, color: colors.textPrimary),
+              onPressed: onMenuTap,
+            )
+          : null,
+      actions: [
+        if (showSearch)
+          IconButton(
+            icon: Icon(Icons.search_rounded, color: colors.textPrimary),
+            onPressed: onSearchTap,
+          ),
+        if (showSettings)
+          IconButton(
+            icon: Icon(Icons.settings_rounded, color: colors.textPrimary),
+            onPressed: onSettingsPressed,
+          ),
+        const SizedBox(width: 8),
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/src/core/presentation/widgets/category_chips.dart
+++ b/lib/src/core/presentation/widgets/category_chips.dart
@@ -27,22 +27,26 @@ class CategoryChips extends StatelessWidget {
           final active = c.id == activeId;
           return Padding(
             padding: const EdgeInsets.only(right: 12),
-            child: InkWell(
-              borderRadius: BorderRadius.circular(24),
-              onTap: () => onTap(c.id),
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
-                decoration: BoxDecoration(
-                  color: active ? colors.selectionEffect : colors.surface,
+            child: ElevatedButton(
+              onPressed: () => onTap(c.id),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: active ? colors.primary : colors.surface,
+                foregroundColor: active ? colors.textLight : colors.textPrimary,
+                shadowColor: Colors.transparent,
+                overlayColor: colors.primaryLight,
+                shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(24),
-                  border: Border.all(color: colors.border),
+                  side: BorderSide(color: colors.border),
                 ),
-                child: Text(
-                  c.name,
-                  style: AppTextStyles.body2Regular.copyWith(
-                    color: active ? colors.primaryDark : colors.textPrimary,
-                    fontWeight: active ? FontWeight.w600 : FontWeight.w400,
-                  ),
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
+                elevation: 0,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              child: Text(
+                c.name,
+                style: AppTextStyles.body2Regular.copyWith(
+                  color: active ? colors.textLight : colors.textPrimary,
+                  fontWeight: active ? FontWeight.w600 : FontWeight.w400,
                 ),
               ),
             ),

--- a/lib/src/core/routes/app_router.dart
+++ b/lib/src/core/routes/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:book_library/src/core/routes/app_routes.dart';
 import 'package:book_library/src/features/home/presentation/view/home_view.dart';
 import 'package:book_library/src/features/launcher/presentation/view/launcher_view.dart';
+import 'package:book_library/src/features/library/presentation/view/library_view.dart';
 import 'package:book_library/src/features/onboard/presentation/view/onboard_view.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
@@ -24,6 +25,11 @@ GoRouter buildRouter() {
         name: AppRoutes.home,
         path: '/home',
         builder: (context, state) => HomeView(viewModel: getIt()),
+      ),
+      GoRoute(
+        path: AppRoutes.library,
+        name: AppRoutes.library,
+        builder: (context, state) => LibraryView(viewModel: getIt()),
       ),
     ],
   );

--- a/lib/src/core/routes/app_routes.dart
+++ b/lib/src/core/routes/app_routes.dart
@@ -8,4 +8,5 @@ abstract class AppRoutes {
   static const String readBook = '/readBook';
   static const String settings = '/settings';
   static const String launcher = '/launcher';
+  static const String library = '/library';
 }

--- a/lib/src/core/theme/app_colors.dart
+++ b/lib/src/core/theme/app_colors.dart
@@ -16,10 +16,12 @@ sealed class AppColors {
     required this.success,
     required this.tapEffect,
     required this.selectionEffect,
+    required this.primaryBlack,
   });
   final Color primary;
   final Color primaryLight;
   final Color primaryDark;
+  final Color primaryBlack;
 
   final Color textPrimary;
   final Color textSecondary;
@@ -43,6 +45,7 @@ class AppColorsLight extends AppColors {
         primary: const Color(0xFF7C3AED),
         primaryLight: const Color(0xFF9F67F8),
         primaryDark: const Color(0xFF5B21B6),
+        primaryBlack: const Color(0xFF2E1065),
         textPrimary: const Color(0xFF111827),
         textSecondary: const Color(0xFF6B7280),
         textLight: const Color(0xFFFFFFFF),
@@ -63,6 +66,7 @@ class AppColorsDark extends AppColors {
         primary: const Color(0xFF9F67F8),
         primaryLight: const Color(0xFFB794F4),
         primaryDark: const Color(0xFF7C3AED),
+        primaryBlack: const Color(0xFFDCCEB0),
         textPrimary: const Color(0xFFF9FAFB),
         textSecondary: const Color(0xFFD1D5DB),
         textLight: const Color(0xFF111827),
@@ -83,6 +87,7 @@ class AppColorsSepia extends AppColors {
         primary: const Color(0xFF7C3AED),
         primaryLight: const Color(0xFF9F67F8),
         primaryDark: const Color(0xFF5B21B6),
+        primaryBlack: const Color(0xFF3B2F2F),
         textPrimary: const Color(0xFF5B4636),
         textSecondary: const Color(0xFF7C6F62),
         textLight: const Color(0xFFFFFFFF),

--- a/lib/src/features/books/presentation/widgets/book_card.dart
+++ b/lib/src/features/books/presentation/widgets/book_card.dart
@@ -13,13 +13,19 @@ class BookCard extends StatelessWidget {
     this.onTap,
     required this.showPercentage,
     required this.showStars,
+    this.percentage = 50,
+    this.coverAspectRatio = 3 / 4,
+    this.coverHeight,
   });
 
   final BookEntity book;
   final ExternalBookInfoEntity? info;
   final VoidCallback? onTap;
+  final int percentage;
   final bool showPercentage;
   final bool showStars;
+  final double coverAspectRatio;
+  final double? coverHeight;
 
   @override
   Widget build(BuildContext context) {
@@ -40,54 +46,50 @@ class BookCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            LayoutBuilder(
-              builder: (context, constraints) {
-                return SizedBox(
-                  width: constraints.maxWidth,
-                  height: 260,
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(12),
-                    child: Builder(
-                      builder: (context) {
-                        if (info == null) {
-                          return const BookCoverPlaceholder();
-                        }
+            SizedBox(
+              width: double.infinity,
+              height: coverHeight,
+              child: AspectRatio(
+                aspectRatio: coverAspectRatio,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: Builder(
+                    builder: (context) {
+                      if (info == null) {
+                        return const BookCoverPlaceholder();
+                      }
 
-                        if (coverUrl != null && coverUrl.isNotEmpty) {
-                          return Image.network(
-                            coverUrl,
-                            fit: BoxFit.cover,
-                            loadingBuilder: (context, child, event) {
-                              if (event == null) return child;
-                              return const BookCoverPlaceholder();
-                            },
-                            errorBuilder: (_, __, ___) => Container(
-                              color: colors.tapEffect,
-                              child: const Center(child: BookCoverPlaceholder(isNotFound: true)),
-                            ),
-                          );
-                        }
-
-                        return Container(
-                          color: colors.tapEffect,
-                          child: const Center(child: BookCoverPlaceholder(isNotFound: true)),
+                      if (coverUrl != null && coverUrl.isNotEmpty) {
+                        return Image.network(
+                          coverUrl,
+                          fit: BoxFit.cover,
+                          loadingBuilder: (context, child, event) {
+                            if (event == null) return child;
+                            return const BookCoverPlaceholder();
+                          },
+                          errorBuilder: (_, __, ___) => Container(
+                            color: colors.tapEffect,
+                            child: const Center(child: BookCoverPlaceholder(isNotFound: true)),
+                          ),
                         );
-                      },
-                    ),
+                      }
+
+                      return Container(
+                        color: colors.tapEffect,
+                        child: const Center(child: BookCoverPlaceholder(isNotFound: true)),
+                      );
+                    },
                   ),
-                );
-              },
+                ),
+              ),
             ),
-
             const SizedBox(height: 12),
-
             Text(
               book.title,
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
               style: AppTextStyles.body1Bold,
             ),
-
             Text(
               book.author,
               maxLines: 1,
@@ -105,19 +107,21 @@ class BookCard extends StatelessWidget {
               ),
               const SizedBox(height: 6),
             ],
-
             if (showPercentage) ...[
               ClipRRect(
                 borderRadius: BorderRadius.circular(8),
                 child: LinearProgressIndicator(
-                  value: 0.5,
+                  value: percentage / 100,
                   backgroundColor: colors.tapEffect,
                   color: colors.primary,
                   minHeight: 6,
                 ),
               ),
               const SizedBox(height: 4),
-              Text('50% read', style: AppTextStyles.caption.copyWith(color: colors.textSecondary)),
+              Text(
+                '$percentage% read',
+                style: AppTextStyles.caption.copyWith(color: colors.textSecondary),
+              ),
             ],
           ],
         ),

--- a/lib/src/features/home/presentation/view/home_view.dart
+++ b/lib/src/features/home/presentation/view/home_view.dart
@@ -1,12 +1,13 @@
 import 'package:book_library/src/core/failures/failures.dart';
 import 'package:book_library/src/core/presentation/views/offiline_view.dart';
+import 'package:book_library/src/core/presentation/widgets/book_library_app_bar.dart';
 import 'package:book_library/src/core/presentation/widgets/book_library_bottom_navigation_bar.dart';
+import 'package:book_library/src/core/presentation/widgets/category_chips.dart';
 import 'package:book_library/src/core/routes/app_routes.dart';
 import 'package:book_library/src/core/state/ui_event.dart';
 import 'package:book_library/src/core/state/view_model_state.dart';
 import 'package:book_library/src/features/home/presentation/view_model/home_view_model.dart';
 import 'package:book_library/src/features/home/presentation/view_model/home_view_model_state.dart';
-import 'package:book_library/src/features/home/presentation/widgets/category_chips.dart';
 import 'package:book_library/src/features/home/presentation/widgets/home_skeleton.dart';
 import 'package:book_library/src/features/home/presentation/widgets/horizontal_books_list.dart';
 import 'package:book_library/src/features/home/presentation/widgets/section_header.dart';
@@ -66,18 +67,11 @@ class _HomeViewState extends State<HomeView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Library'),
-        centerTitle: true,
-        leading: IconButton(icon: const Icon(Icons.menu_rounded), onPressed: () {}),
-        actions: [
-          IconButton(icon: const Icon(Icons.search_rounded), onPressed: () {}),
-          IconButton(
-            icon: const Icon(Icons.settings_outlined),
-            onPressed: () => context.goNamed(AppRoutes.settings),
-          ),
-          const SizedBox(width: 8),
-        ],
+      appBar: const BookLibraryAppBar(
+        title: 'Library',
+        showMenu: true,
+        showSearch: true,
+        showSettings: true,
       ),
       bottomNavigationBar: const BookLibraryBottomNavigationBar(),
       body: SafeArea(
@@ -104,7 +98,11 @@ class _HomeViewState extends State<HomeView> {
                     activeId: data.activeCategoryId,
                     onTap: viewModel.selectCategory,
                   ),
-                  SectionHeader(title: 'Library', action: 'See all', onTap: () {}),
+                  SectionHeader(
+                    title: 'Library',
+                    action: 'See all',
+                    onTap: () => context.pushNamed(AppRoutes.library),
+                  ),
                   HorizontalBooksList(
                     byBookId: viewModel.byBookId,
                     resolveFor: viewModel.resolveFor,

--- a/lib/src/features/home/presentation/widgets/horizontal_books_list.dart
+++ b/lib/src/features/home/presentation/widgets/horizontal_books_list.dart
@@ -42,6 +42,7 @@ class HorizontalBooksList extends StatelessWidget {
                 book: book,
                 info: info,
                 onTap: () {},
+
                 showPercentage: showPercentage,
                 showStars: showStars,
               );

--- a/lib/src/features/library/presentation/view/library_view.dart
+++ b/lib/src/features/library/presentation/view/library_view.dart
@@ -1,0 +1,208 @@
+import 'package:book_library/src/core/presentation/extensions/color_ext.dart';
+import 'package:book_library/src/core/presentation/widgets/category_chips.dart';
+import 'package:book_library/src/core/state/ui_event.dart';
+import 'package:book_library/src/core/state/view_model_state.dart';
+import 'package:book_library/src/core/theme/app_text_styles.dart';
+import 'package:book_library/src/features/books/presentation/widgets/book_card.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/library/presentation/view_model/library_view_model.dart';
+import 'package:book_library/src/features/library/presentation/view_model/library_view_model_data.dart';
+import 'package:book_library/src/features/library/presentation/widgets/library_skeleton.dart';
+import 'package:flutter/material.dart';
+
+class LibraryView extends StatefulWidget {
+  const LibraryView({super.key, required this.viewModel});
+  final LibraryViewModel viewModel;
+
+  @override
+  State<LibraryView> createState() => _LibraryViewState();
+}
+
+class _LibraryViewState extends State<LibraryView> {
+  late final LibraryViewModel vm = widget.viewModel;
+
+  VoidCallback? _eventL;
+
+  @override
+  void initState() {
+    super.initState();
+    vm.load();
+
+    _eventL = () {
+      final evt = vm.event.value;
+      if (evt == null || !mounted) return;
+
+      if (evt is ShowErrorSnackBar) {
+        final c = Theme.of(context).colors;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            backgroundColor: c.error,
+            content: Row(
+              children: [
+                Icon(Icons.error_outline, color: c.textLight),
+                const SizedBox(width: 8),
+                Text(evt.message, style: AppTextStyles.body2Regular.copyWith(color: c.textLight)),
+              ],
+            ),
+          ),
+        );
+      } else if (evt is ShowSnackBar) {
+        final c = Theme.of(context).colors;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            backgroundColor: c.primary,
+            content: Row(
+              children: [
+                Icon(Icons.info_outline, color: c.textLight),
+                const SizedBox(width: 8),
+                Text(evt.message, style: AppTextStyles.body2Regular.copyWith(color: c.textLight)),
+              ],
+            ),
+          ),
+        );
+      }
+      vm.consumeEvent();
+    };
+    vm.event.addListener(_eventL!);
+  }
+
+  @override
+  void dispose() {
+    if (_eventL != null) vm.event.removeListener(_eventL!);
+    super.dispose();
+  }
+
+  Future<void> _onRefresh() => vm.load();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colors;
+
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: Text('Library', style: AppTextStyles.h6.copyWith(color: colors.textPrimary)),
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back_rounded, color: colors.textPrimary),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.search_rounded, color: colors.textPrimary),
+            onPressed: () {},
+          ),
+          const SizedBox(width: 8),
+        ],
+      ),
+      body: SafeArea(
+        child: ValueListenableBuilder<ViewModelState<dynamic, LibraryData>>(
+          valueListenable: vm.state,
+          builder: (context, st, _) {
+            if (st is LoadingState) return const LibrarySkeleton();
+            if (st is ErrorState) {
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.wifi_off_rounded, size: 56, color: colors.textSecondary),
+                      const SizedBox(height: 12),
+                      Text('Something went wrong', style: AppTextStyles.h6),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Please check your connection and try again.',
+                        style: AppTextStyles.body2Regular.copyWith(color: colors.textSecondary),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 16),
+                      ElevatedButton(onPressed: vm.load, child: const Text('Retry')),
+                    ],
+                  ),
+                ),
+              );
+            }
+
+            if (st is SuccessState<dynamic, LibraryData>) {
+              final data = st.success;
+              final items = data.items;
+
+              return RefreshIndicator(
+                onRefresh: _onRefresh,
+                child: CustomScrollView(
+                  slivers: [
+                    SliverToBoxAdapter(
+                      child: CategoryChips(
+                        items: data.categories,
+                        activeId: data.activeCategoryId,
+                        onTap: vm.selectCategory,
+                      ),
+                    ),
+                    ValueListenableBuilder<Map<String, ExternalBookInfoEntity>>(
+                      valueListenable: vm.byBookId,
+                      builder: (context, infos, __) {
+                        return SliverToBoxAdapter(
+                          child: LayoutBuilder(
+                            builder: (context, constraints) {
+                              final cols = constraints.maxWidth >= 700 ? 3 : 2;
+
+                              const hSpacing = 16.0;
+
+                              final cellWidth = (constraints.maxWidth - 64) / cols;
+                              const coverAspect = 3 / 4;
+                              final coverHeight = cellWidth / coverAspect;
+                              final cellHeight = coverHeight + 128;
+
+                              final ratio = ((constraints.maxWidth - 64) / cols) / cellHeight;
+
+                              return CustomScrollView(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                slivers: [
+                                  SliverPadding(
+                                    padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+                                    sliver: SliverGrid(
+                                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                                        crossAxisCount: cols,
+                                        mainAxisSpacing: hSpacing,
+                                        crossAxisSpacing: hSpacing,
+                                        childAspectRatio: ratio,
+                                      ),
+                                      delegate: SliverChildBuilderDelegate((context, index) {
+                                        final book = items[index];
+                                        final info = infos[book.id];
+
+                                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                                          vm.resolveFor(book);
+                                        });
+
+                                        return BookCard(
+                                          book: book,
+                                          info: info,
+                                          showStars: true,
+                                          showPercentage: true,
+                                          coverAspectRatio: coverAspect,
+                                          coverHeight: null,
+                                        );
+                                      }, childCount: items.length),
+                                    ),
+                                  ),
+                                ],
+                              );
+                            },
+                          ),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              );
+            }
+
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/library/presentation/view_model/library_view_model.dart
+++ b/lib/src/features/library/presentation/view_model/library_view_model.dart
@@ -1,0 +1,117 @@
+import 'package:book_library/src/core/failures/failures.dart';
+import 'package:book_library/src/core/state/ui_event.dart';
+import 'package:book_library/src/core/state/view_model_state.dart';
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_all_books_use_case.dart';
+import 'package:book_library/src/features/books/domain/usecases/get_categories_use_case.dart';
+import 'package:book_library/src/features/books_details/domain/entites/external_book_info_entity.dart';
+import 'package:book_library/src/features/books_details/services/external_book_info_resolver.dart';
+import 'package:book_library/src/features/library/presentation/view_model/library_view_model_data.dart';
+import 'package:flutter/foundation.dart';
+
+// Disclaimer: Se houvesse outros endpoints para carregar livros lidos recentemente,
+// fariamos o prefetch dos itens filtrados aqui. Neste caso, apenas reutilizamos o GetAllBooksUseCase
+// para simplificar o exemplo.
+//
+// ...
+// Além do mais preciso simplificar algumas coisas, afinal, só tenho 7 dias para fazer tudo isso :)
+
+class LibraryViewModel {
+  LibraryViewModel(this._getBooks, this._getCategories, this._resolver);
+
+  final GetAllBooksUseCase _getBooks;
+  final GetCategoriesUseCase _getCategories;
+  final ExternalBookInfoResolver _resolver;
+
+  // Eu nem falei isso na vm do home, mas vi esse padrão do LibraryData em mais projetos.
+  // pesquisei sobre e descobri que esse padrão do LibraryData (que obviamente é um ValueObject)
+  // é a base para diversos gerenciadores de estado, como o BLoC.
+  // Juntar tudo em um único objeto facilita o gerenciamento do estado.
+  // O Equatable ajuda a comparar instâncias e otimizar atualizações de UI.
+  // Acho que vale a pena manter esse padrão... pelo menos nesse projeto.
+  final ValueNotifier<ViewModelState<Failure, LibraryData>> state =
+      ValueNotifier<ViewModelState<Failure, LibraryData>>(InitialState());
+
+  final ValueNotifier<UiEvent?> event = ValueNotifier<UiEvent?>(null);
+
+  // Já isso aqui é interessante, em um momento eu pensei, poxa, esse cache deveria ser
+  // global, mas depois pensei melhor e percebi que não.
+  // Se o usuário nunca entrar na tela de detalhes, não faz sentido carregar e manter
+  // esses dados na memória. Pior, digamos que ele esteja sendo usado somente para mostrar a imagem
+  // da capa do livro (quando acha), os proximos livros podem ser diferentes, e manter eles na memória
+  // não significa que serão usados novamente.
+  // Então, faz sentido manter esse cache aqui, e quando o usuário sair da tela de biblioteca, tudo será descartado.
+  // Se ele voltar, os dados serão recarregados.
+  // Se o usuário entrar na tela de detalhes, aí sim, faz sentido manter esses dados na memória, afinal, ele pode navegar
+  // entre diversos livros, e não faz sentido ficar recarregando os dados toda hora.
+  // (Indo pra o detalhe, voltando pra biblioteca, indo pro detalhe de novo, etc).
+  // Afinal foi como eu disse, mesmo que o usuário volte para a tela home, não significa que ele vá querer ver os mesmos livros.
+  //
+  // ... na verdade, eu poderia por exemplo, antes de procurar novos dados, verificar se o livro já não existe no cache anterior,
+  // o cache que está na home por exemplo precisaria estar em outro lugar, pra que eu pudesse reutilizá-lo,
+  // mas eu teria que ver se realmente vale a pena...
+  //
+  // e isso daí já é demais só pra um exemplo hahaha
+  final ValueNotifier<Map<String, ExternalBookInfoEntity>> byBookId = ValueNotifier(
+    <String, ExternalBookInfoEntity>{},
+  );
+
+  Future<void> load() async {
+    state.value = LoadingState();
+
+    final catsEither = await _getCategories();
+    await catsEither.fold(
+      (f) {
+        state.value = ErrorState(f);
+        event.value = ShowErrorSnackBar(f.message);
+      },
+      (cats) async {
+        final booksEither = await _getBooks();
+        booksEither.fold(
+          (f) {
+            state.value = ErrorState(f);
+            event.value = ShowErrorSnackBar(f.message);
+          },
+          (books) {
+            final data = LibraryData(
+              categories: cats,
+              items: books,
+              activeCategoryId: cats.isNotEmpty ? cats.first.id : null,
+            );
+            state.value = SuccessState(data);
+
+            _prefetchFor(books.take(8));
+          },
+        );
+      },
+    );
+  }
+
+  void selectCategory(String id) {
+    final current = state.value;
+    if (current is SuccessState<Failure, LibraryData>) {
+      if (current.success.activeCategoryId == id) return;
+      state.value = SuccessState(current.success.copyWith(activeCategoryId: id));
+
+      _prefetchFor(current.success.items.take(8));
+    }
+  }
+
+  Future<void> resolveFor(BookEntity book) async {
+    if (byBookId.value.containsKey(book.id)) return;
+
+    final info = await _resolver.resolve(book.title, book.author);
+    if (info != null) {
+      final next = Map<String, ExternalBookInfoEntity>.from(byBookId.value);
+      next[book.id] = info;
+      byBookId.value = next;
+    }
+  }
+
+  Future<void> _prefetchFor(Iterable<BookEntity> books) async {
+    final pairs = books.map((b) => (title: b.title, author: b.author));
+    await _resolver.prefetch(pairs);
+  }
+
+  void consumeEvent() => event.value = null;
+}

--- a/lib/src/features/library/presentation/view_model/library_view_model_data.dart
+++ b/lib/src/features/library/presentation/view_model/library_view_model_data.dart
@@ -1,0 +1,26 @@
+import 'package:book_library/src/features/books/domain/entities/book_entity.dart';
+import 'package:book_library/src/features/books/domain/entities/category_entity.dart';
+import 'package:equatable/equatable.dart';
+
+class LibraryData extends Equatable {
+  const LibraryData({required this.categories, required this.items, this.activeCategoryId});
+
+  final List<CategoryEntity> categories;
+  final List<BookEntity> items;
+  final String? activeCategoryId;
+
+  LibraryData copyWith({
+    List<CategoryEntity>? categories,
+    List<BookEntity>? items,
+    String? activeCategoryId,
+  }) {
+    return LibraryData(
+      categories: categories ?? this.categories,
+      items: items ?? this.items,
+      activeCategoryId: activeCategoryId ?? this.activeCategoryId,
+    );
+  }
+
+  @override
+  List<Object?> get props => [categories, items, activeCategoryId];
+}

--- a/lib/src/features/library/presentation/widgets/library_skeleton.dart
+++ b/lib/src/features/library/presentation/widgets/library_skeleton.dart
@@ -1,0 +1,85 @@
+import 'package:book_library/src/core/presentation/extensions/color_ext.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class LibrarySkeleton extends StatelessWidget {
+  const LibrarySkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colors;
+    final base = colors.tapEffect;
+    final highlight = colors.tapEffect.withAlpha(200);
+
+    Widget block({double? w, double? h, BorderRadius? r, EdgeInsets? m}) {
+      return Shimmer.fromColors(
+        baseColor: base,
+        highlightColor: highlight,
+        child: Container(
+          width: w,
+          height: h,
+          margin: m,
+          decoration: BoxDecoration(
+            color: base,
+            borderRadius: r ?? BorderRadius.circular(8),
+            border: Border.all(color: colors.border),
+          ),
+        ),
+      );
+    }
+
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+            child: Row(
+              children: List.generate(
+                5,
+                (_) => block(
+                  w: 90,
+                  h: 36,
+                  r: BorderRadius.circular(24),
+                  m: const EdgeInsets.only(right: 12),
+                ),
+              ),
+            ),
+          ),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+          sliver: SliverGrid(
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              crossAxisSpacing: 16,
+              mainAxisSpacing: 16,
+              childAspectRatio: 0.62,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, _) => Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: colors.surface,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: colors.border),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    block(h: 180, r: BorderRadius.circular(12)),
+                    const SizedBox(height: 12),
+                    block(h: 14, w: 160),
+                    const SizedBox(height: 8),
+                    block(h: 12, w: 100),
+                  ],
+                ),
+              ),
+              childCount: 6,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- Add `LibraryView` with responsive sliver grid and pull-to-refresh
- Integrate `LibraryViewModel` (ValueNotifiers + UiEvent) and `LibraryData`
- Plug external book info resolver (cover/extra details per book)
- Add error handling (offline state), snackbars and event consumption
- Add `LibrarySkeleton` with shimmer placeholders
- Add reusable `BookLibraryAppBar` and `CategoryChips`
- Reuse `BookCard` with configurable cover ratio/height
- Wire DI and routes for Library feature
- Minor style tweaks (colors/typography) to match design